### PR TITLE
Port IPOR Fusion vault work and ERC4626 strategies; add bdUSD and BTCdc

### DIFF
--- a/contracts/base/HookVaultV2.sol
+++ b/contracts/base/HookVaultV2.sol
@@ -44,6 +44,8 @@ contract HookVaultV2 is VaultV2 {
 
   event DepositCapChanged(uint256 oldCap, uint256 newCap);
   event CompoundOnWithdrawChanged(bool value);
+  /// @notice The strategy refused the withdrawal-time hard work; the exit was priced without it.
+  event HardWorkOnWithdrawSkipped();
 
   constructor() {
     assert(_DEPOSIT_CAP_SLOT == bytes32(uint256(keccak256("eip1967.vaultStorage.depositCap")) - 1));
@@ -134,13 +136,30 @@ contract HookVaultV2 is VaultV2 {
    * @notice Runs the withdrawal-side hard work for the current strategy.
    * @dev Uses {IHardWorkHooks-doHardWorkOnWithdraw} when the strategy supports it,
    * otherwise falls back to `IStrategy.doHardWork()`.
+   *
+   * Compounding on the way out is a courtesy - it credits the exiting user the interest
+   * accrued since the last hard work - and it must never be able to block the exit itself.
+   * A strategy in its emergency state refuses `doHardWork()`, and that is precisely when
+   * holders most need to leave; a vault with no strategy has nothing to call at all. Both
+   * degrade to the pricing a stock `VaultV2` would have used.
    */
   function _hardWorkOnWithdraw() internal {
     address _strategy = strategy();
+    if (_strategy == address(0)) {
+      return;
+    }
     if (_supportsHardWorkHooks(_strategy)) {
-      IHardWorkHooks(_strategy).doHardWorkOnWithdraw();
+      try IHardWorkHooks(_strategy).doHardWorkOnWithdraw() {
+        return;
+      } catch {
+        emit HardWorkOnWithdrawSkipped();
+      }
     } else {
-      IStrategy(_strategy).doHardWork();
+      try IStrategy(_strategy).doHardWork() {
+        return;
+      } catch {
+        emit HardWorkOnWithdrawSkipped();
+      }
     }
   }
 

--- a/contracts/base/HookVaultV2.sol
+++ b/contracts/base/HookVaultV2.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.26;
+
+import "./VaultV2.sol";
+import "./interface/IHardWorkHooks.sol";
+
+/**
+ * @title HookVaultV2
+ * @dev A `VaultV2` with two governance-controlled additions. Both are off by default, so
+ * a freshly deployed or upgraded vault behaves exactly like `VaultV2` until governance
+ * turns one on.
+ *
+ * `compoundOnWithdraw`: run the strategy's hard work before pricing a withdrawal, so the
+ * exiting user is credited the interest accrued since the last hard work rather than
+ * leaving it to the remaining holders. `doHardWork()` also ends by depositing idle
+ * underlying into the yield source, and the vault then redeems from that same yield
+ * source a few lines later. Yield sources that forbid depositing and redeeming together
+ * - a redemption delay, a withdrawal queue - reject that second call and the withdrawal
+ * reverts. So the vault asks the strategy whether it implements {IHardWorkHooks}. If it
+ * does, the withdrawal path calls `doHardWorkOnWithdraw()` instead, which credits the
+ * same accrued interest without depositing. If it does not, the vault calls
+ * `doHardWork()`.
+ *
+ * `depositCap`: a maximum total underlying the vault may hold, checked before any funds
+ * move and reported through the ERC-4626 `maxDeposit`/`maxMint` views.
+ *
+ * The deposit path is otherwise untouched, and a deposit never runs a hard work.
+ *
+ * Storage layout and every other entrypoint are inherited from `VaultV2` unchanged; the
+ * two settings live in dedicated hashed slots, so this is a drop-in implementation for
+ * an existing vault proxy.
+ */
+contract HookVaultV2 is VaultV2 {
+  // `using ... for` is not inherited, so the directives VaultV1 relies on are repeated
+  // here for the function bodies this contract overrides.
+  using SafeERC20Upgradeable for IERC20Upgradeable;
+  using SafeMathUpgradeable for uint256;
+
+  /// @dev keccak256("eip1967.vaultStorage.depositCap") - 1. A dedicated hashed slot, so
+  /// adding it leaves the inherited storage layout untouched.
+  bytes32 internal constant _DEPOSIT_CAP_SLOT = 0xd835bdd7ad461b0c86e99a3d099e26b9deeba4c35acaddbb2e0d9d5b3aa58781;
+  /// @dev keccak256("eip1967.vaultStorage.compoundOnWithdraw") - 1.
+  bytes32 internal constant _COMPOUND_ON_WITHDRAW_SLOT = 0x724ff40d01b658bcc822d9ceb05c9e2f446998b3033585f9bcac7fd7929aaca7;
+
+  event DepositCapChanged(uint256 oldCap, uint256 newCap);
+  event CompoundOnWithdrawChanged(bool value);
+
+  constructor() {
+    assert(_DEPOSIT_CAP_SLOT == bytes32(uint256(keccak256("eip1967.vaultStorage.depositCap")) - 1));
+    assert(_COMPOUND_ON_WITHDRAW_SLOT == bytes32(uint256(keccak256("eip1967.vaultStorage.compoundOnWithdraw")) - 1));
+  }
+
+  /**
+   * @notice Maximum total underlying the vault may hold. Zero means uncapped, which is
+   * the default for every newly deployed vault.
+   * @return The cap in underlying, or 0 if there is none.
+   */
+  function depositCap() public view returns (uint256) {
+    return getUint256(_DEPOSIT_CAP_SLOT);
+  }
+
+  /**
+   * @notice Sets the deposit cap, denominated in the underlying asset. Effective
+   * immediately, with no timelock. A cap of 0 disables it.
+   * @dev Setting a cap below current TVL does not force anything out; it only stops
+   * further deposits until TVL falls back under the cap.
+   * @param cap Maximum total underlying the vault may hold; 0 disables the cap.
+   */
+  function setDepositCap(uint256 cap) external onlyGovernance {
+    emit DepositCapChanged(depositCap(), cap);
+    setUint256(_DEPOSIT_CAP_SLOT, cap);
+  }
+
+  /**
+   * @notice Whether a withdrawal runs the strategy's hard work before it is priced.
+   * Off by default.
+   * @return True if withdrawals compound first.
+   */
+  function compoundOnWithdraw() public view returns (bool) {
+    return getBoolean(_COMPOUND_ON_WITHDRAW_SLOT);
+  }
+
+  /**
+   * @notice Turns `compoundOnWithdraw` on or off. Effective immediately, no timelock.
+   * @param value True to run the hard work inside withdrawals.
+   */
+  function setCompoundOnWithdraw(bool value) external onlyGovernance {
+    setBoolean(_COMPOUND_ON_WITHDRAW_SLOT, value);
+    emit CompoundOnWithdrawChanged(value);
+  }
+
+  /**
+   * @notice Remaining capacity under the deposit cap.
+   * @dev Reports the real limit so an ERC-4626 integrator sizing a deposit from this
+   * value is not handed `type(uint256).max` and then reverted by the cap. Slightly
+   * conservative in one direction only: TVL can grow between this call and the deposit,
+   * so a deposit of exactly this size may still be rejected. Exact when uncapped.
+   * @return Remaining depositable underlying, or `type(uint256).max` if uncapped.
+   */
+  function maxDeposit(address /*caller*/) public view override returns (uint256) {
+    uint256 cap = depositCap();
+    if (cap == 0) return type(uint256).max;
+    uint256 tvl = totalAssets();
+    return cap > tvl ? cap - tvl : 0;
+  }
+
+  /**
+   * @notice Shares mintable under the deposit cap.
+   * @param _caller Address that would mint.
+   * @return Mintable shares, or `type(uint256).max` if uncapped.
+   */
+  function maxMint(address _caller) public view override returns (uint256) {
+    if (depositCap() == 0) return type(uint256).max;
+    return convertToShares(maxDeposit(_caller));
+  }
+
+  /**
+   * @notice Deposits underlying assets and mints shares, enforcing the deposit cap.
+   * @dev A thin wrapper: the cap is checked against pre-deposit TVL plus this deposit,
+   * before `VaultV1._deposit` pulls any funds. Uncapped vaults reach `super` after one
+   * storage read.
+   * @param amount Amount of underlying assets to deposit.
+   * @param sender Address providing the assets.
+   * @param beneficiary Address to receive the shares.
+   * @return Amount of shares minted.
+   */
+  function _deposit(uint256 amount, address sender, address beneficiary) internal virtual override returns (uint256) {
+    uint256 cap = depositCap();
+    require(cap == 0 || underlyingBalanceWithInvestment().add(amount) <= cap, "Deposit cap reached");
+    return super._deposit(amount, sender, beneficiary);
+  }
+
+  /**
+   * @notice Runs the withdrawal-side hard work for the current strategy.
+   * @dev Uses {IHardWorkHooks-doHardWorkOnWithdraw} when the strategy supports it,
+   * otherwise falls back to `IStrategy.doHardWork()`.
+   */
+  function _hardWorkOnWithdraw() internal {
+    address _strategy = strategy();
+    if (_supportsHardWorkHooks(_strategy)) {
+      IHardWorkHooks(_strategy).doHardWorkOnWithdraw();
+    } else {
+      IStrategy(_strategy).doHardWork();
+    }
+  }
+
+  /**
+   * @notice Whether the strategy implements the optional hard work hooks.
+   * @dev A plain staticcall: a strategy without the function reverts, which reads as
+   * "not supported". Deliberately does not treat a revert as an error - that is the
+   * signal. Requires an exact 32-byte `true` so a proxy fallback returning empty or
+   * arbitrary data cannot be mistaken for support.
+   * @param _strategy Address of the strategy to probe.
+   * @return True if the hook is implemented and should be used.
+   */
+  function _supportsHardWorkHooks(address _strategy) internal view returns (bool) {
+    (bool success, bytes memory data) = _strategy.staticcall(
+      abi.encodeWithSelector(IHardWorkHooks.supportsHardWorkHooks.selector)
+    );
+    if (!success || data.length != 32) {
+      return false;
+    }
+    // Compared as uint256 against the canonical encoding of `true`. Decoding as a bool
+    // would panic on a word that is neither 0 nor 1, taking the withdrawal down with it;
+    // anything that is not exactly `true` should simply read as "not supported" and fall
+    // back to doHardWork().
+    return abi.decode(data, (uint256)) == 1;
+  }
+
+  /**
+   * @notice Burns shares and returns underlying assets, running the strategy's hard work
+   * first when `compoundOnWithdraw` is on.
+   * @dev Identical to `VaultV1._withdraw` apart from the hard work call.
+   * @param numberOfShares Amount of shares to redeem.
+   * @param receiver Address to receive the underlying assets.
+   * @param owner Address holding the shares to redeem.
+   * @return Amount of underlying assets received.
+   */
+  function _withdraw(uint256 numberOfShares, address receiver, address owner) internal virtual override returns (uint256) {
+    require(totalSupply() > 0, "Vault has no shares");
+    require(numberOfShares > 0, "numberOfShares must be greater than 0");
+    uint256 totalSupply = totalSupply();
+
+    address sender = msg.sender;
+    if (sender != owner) {
+      uint256 currentAllowance = allowance(owner, sender);
+      if (currentAllowance != uint(type(uint).max)) {
+        require(currentAllowance >= numberOfShares, "ERC20: transfer amount exceeds allowance");
+        _approve(owner, sender, currentAllowance - numberOfShares);
+      }
+    }
+    _burn(owner, numberOfShares);
+
+    if (compoundOnWithdraw()) {
+      _hardWorkOnWithdraw();
+    }
+
+    uint256 underlyingAmountToWithdraw = underlyingBalanceWithInvestment()
+        .mul(numberOfShares)
+        .div(totalSupply);
+    if (underlyingAmountToWithdraw > underlyingBalanceInVault()) {
+      // withdraw everything from the strategy to accurately check the share value
+      if (numberOfShares == totalSupply) {
+        IStrategy(strategy()).withdrawAllToVault();
+      } else {
+        uint256 missing = underlyingAmountToWithdraw.sub(underlyingBalanceInVault());
+        IStrategy(strategy()).withdrawToVault(missing);
+      }
+      // recalculate to improve accuracy
+      underlyingAmountToWithdraw = MathUpgradeable.min(underlyingBalanceWithInvestment()
+          .mul(numberOfShares)
+          .div(totalSupply), underlyingBalanceInVault());
+    }
+
+    IERC20Upgradeable(underlying()).safeTransfer(receiver, underlyingAmountToWithdraw);
+
+    // update the withdrawal amount for the holder
+    emit IERC4626.Withdraw(sender, receiver, owner, underlyingAmountToWithdraw, numberOfShares);
+    return underlyingAmountToWithdraw;
+  }
+}

--- a/contracts/base/VaultV1.sol
+++ b/contracts/base/VaultV1.sol
@@ -267,7 +267,7 @@ contract VaultV1 is ERC20Upgradeable, IUpgradeSource, ControllableInit, VaultSto
     IStrategy(strategy()).withdrawAllToVault();
   }
 
-  function _deposit(uint256 amount, address sender, address beneficiary) internal returns (uint256) {
+  function _deposit(uint256 amount, address sender, address beneficiary) internal virtual returns (uint256) {
     require(amount > 0, "Cannot deposit 0");
     require(beneficiary != address(0), "holder must be defined");
 
@@ -287,7 +287,7 @@ contract VaultV1 is ERC20Upgradeable, IUpgradeSource, ControllableInit, VaultSto
     return toMint;
   }
 
-  function _withdraw(uint256 numberOfShares, address receiver, address owner) internal returns (uint256) {
+  function _withdraw(uint256 numberOfShares, address receiver, address owner) internal virtual returns (uint256) {
     require(totalSupply() > 0, "Vault has no shares");
     require(numberOfShares > 0, "numberOfShares must be greater than 0");
     uint256 totalSupply = totalSupply();

--- a/contracts/base/VaultV2.sol
+++ b/contracts/base/VaultV2.sol
@@ -25,7 +25,7 @@ contract VaultV2 is IERC4626, VaultV1 {
         return totalAssets() * balanceOf(_depositor) / totalSupply();
     }
 
-    function maxDeposit(address /*caller*/) public view override returns (uint256) {
+    function maxDeposit(address /*caller*/) public view virtual override returns (uint256) {
         return uint(type(uint).max);
     }
 
@@ -38,7 +38,7 @@ contract VaultV2 is IERC4626, VaultV1 {
         return shares;
     }
 
-    function maxMint(address /*caller*/) public view override returns (uint256) {
+    function maxMint(address /*caller*/) public view virtual override returns (uint256) {
         return uint(type(uint).max);
     }
 

--- a/contracts/base/interface/IHardWorkHooks.sol
+++ b/contracts/base/interface/IHardWorkHooks.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.26;
+
+/**
+ * @title IHardWorkHooks
+ * @dev Optional strategy interface for strategies that cannot deposit into their yield
+ * source inside a user's withdrawal transaction.
+ *
+ * `compoundOnWithdraw` exists so that an exiting user is credited the interest accrued
+ * since the last hard work, rather than leaving it to the remaining holders. The vault
+ * achieves that by calling `IStrategy.doHardWork()` before it prices the withdrawal.
+ *
+ * For most strategies that is fine. But `doHardWork()` also ends by depositing idle
+ * underlying into the yield source, and the vault then redeems from that same yield
+ * source later in the same transaction. Some yield sources forbid that pairing - a
+ * redemption delay, a withdrawal queue, or a same-block deposit/withdraw restriction -
+ * and the withdrawal reverts.
+ *
+ * A strategy implementing this interface offers a withdrawal-safe subset: accrue fees,
+ * liquidate rewards and refresh the stored balance - everything that credits the exiting
+ * user - while leaving the deposit to the next `doHardWork()`.
+ *
+ * `doHardWork()` itself is unchanged and still deposits, so keepers need no
+ * reconfiguration and the deposit path is unaffected.
+ */
+interface IHardWorkHooks {
+    /**
+     * @notice Whether this strategy implements the hard work hook below.
+     * @dev Vaults staticcall this to decide whether to use the hook or fall back to
+     * `IStrategy.doHardWork()`. Implementations must return true; a strategy that does
+     * not implement the interface simply has no such function and the staticcall fails
+     * or returns nothing, which the vault treats as "not supported".
+     * @return True if `doHardWorkOnWithdraw` is implemented.
+     */
+    function supportsHardWorkHooks() external view returns (bool);
+
+    /**
+     * @notice Hard work to run inside a user's withdrawal transaction.
+     * @dev Must credit accrued interest the same way `doHardWork()` would, but must not
+     * deposit into the underlying yield source, because the vault may redeem from it
+     * later in the same transaction.
+     */
+    function doHardWorkOnWithdraw() external;
+}

--- a/contracts/strategies/erc4626/GeneralERC4626Strategy.sol
+++ b/contracts/strategies/erc4626/GeneralERC4626Strategy.sol
@@ -26,6 +26,7 @@ contract GeneralERC4626Strategy is BaseUpgradeableStrategy, IHardWorkHooks {
   bytes32 internal constant _FTOKEN_SLOT = 0x462e4d44c9bae3e0ee3d71929710bef82ca7c929ce31980e75572ea415835b0e;
   bytes32 internal constant _STORED_SUPPLIED_SLOT = 0x280539da846b4989609abdccfea039bd1453e4f710c670b29b9eeaca0730c1a2;
   bytes32 internal constant _PENDING_FEE_SLOT = 0x0af7af9f5ccfa82c3497f40c7c382677637aee27293a6243a22216b51481bd97;
+  bytes32 internal constant _LOSS_CARRY_SLOT = 0x41899daaeb9cc577a761309ed45b44d3e89e0a9eaa6cd4333a3ebb5fa844d157;
 
   // this would be reset on each upgrade
   address[] public rewardTokens;
@@ -46,6 +47,7 @@ contract GeneralERC4626Strategy is BaseUpgradeableStrategy, IHardWorkHooks {
     assert(_FTOKEN_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.fToken")) - 1));
     assert(_STORED_SUPPLIED_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.storedSupplied")) - 1));
     assert(_PENDING_FEE_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.pendingFee")) - 1));
+    assert(_LOSS_CARRY_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.lossCarry")) - 1));
   }
 
   /**
@@ -130,15 +132,54 @@ contract GeneralERC4626Strategy is BaseUpgradeableStrategy, IHardWorkHooks {
   }
 
   /**
-   * @notice Accrues fees based on the increase in balance.
+   * @notice Value the position has lost and not yet earned back. No performance fee is
+   * charged until it has.
+   * @return The unrecovered loss, in underlying.
+   */
+  function lossCarry() public view returns (uint256) {
+    return getUint256(_LOSS_CARRY_SLOT);
+  }
+
+  /**
+   * @notice Accrues the performance fee on the gain since the last call, above the high
+   * water mark.
+   * @dev `storedBalance` cannot itself be the high water mark: it has to track the real
+   * size of the position, which supplying and redeeming legitimately move. So a drop in
+   * value is remembered separately in `lossCarry` and offsets later gains, and only what
+   * is left is charged.
+   *
+   * Every caller runs this BEFORE it supplies or redeems in the same transaction, and
+   * `_updateStoredBalance()` runs after, so the difference measured here is always a pure
+   * change in value and never the strategy's own deposits or withdrawals.
+   *
+   * Without this, a dip resets the mark and depositors are charged the full fee for
+   * earning their own loss back. These are actively managed vaults whose NAV does fall -
+   * on a management-fee share mint, a rebalance, or a market-balance refresh - so over a
+   * saw-toothing period the fee taken would otherwise run well past the intended share of
+   * true net profit.
    */
   function _accrueFee() internal {
-    uint256 fee;
-    if (currentBalance() > storedBalance()) {
-      uint256 balanceIncrease = currentBalance().sub(storedBalance());
-      fee = balanceIncrease.mul(totalFeeNumerator()).div(feeDenominator());
+    uint256 balance = currentBalance();
+    uint256 stored = storedBalance();
+
+    if (balance < stored) {
+      setUint256(_LOSS_CARRY_SLOT, lossCarry().add(stored.sub(balance)));
+      return;
     }
-    setUint256(_PENDING_FEE_SLOT, pendingFee().add(fee));
+    if (balance == stored) {
+      return;
+    }
+
+    uint256 gain = balance.sub(stored);
+    uint256 carry = lossCarry();
+    if (carry > 0) {
+      uint256 recovered = Math.min(carry, gain);
+      setUint256(_LOSS_CARRY_SLOT, carry.sub(recovered));
+      gain = gain.sub(recovered);
+    }
+    if (gain > 0) {
+      setUint256(_PENDING_FEE_SLOT, pendingFee().add(gain.mul(totalFeeNumerator()).div(feeDenominator())));
+    }
   }
 
   /**

--- a/contracts/strategies/erc4626/GeneralERC4626Strategy.sol
+++ b/contracts/strategies/erc4626/GeneralERC4626Strategy.sol
@@ -137,12 +137,22 @@ contract GeneralERC4626Strategy is BaseUpgradeableStrategy, IHardWorkHooks {
   }
 
   /**
+   * @notice Smallest fee worth paying out. Below this it stays pending and is retried on
+   * the next call, rather than spending gas forwarding dust.
+   * @dev Virtual so a strategy on a low-decimal underlying can lower it.
+   * @return The floor, in underlying.
+   */
+  function feeFloor() public view virtual returns (uint256) {
+    return 1e3;
+  }
+
+  /**
    * @notice Processes any pending fees, redeems the fee amount, and sends to the controller.
    */
   function _handleFee() internal {
     _accrueFee();
     uint256 fee = pendingFee();
-    if (fee > 1e3) {
+    if (fee > feeFloor()) {
       address _underlying = underlying();
       uint256 availableBalance = IERC20(_underlying).balanceOf(address(this));
       if (availableBalance < fee) {
@@ -199,8 +209,14 @@ contract GeneralERC4626Strategy is BaseUpgradeableStrategy, IHardWorkHooks {
     _handleFee();
     address _underlying = underlying();
     _redeemAll();
-    if (IERC20(_underlying).balanceOf(address(this)) > 0) {
-      IERC20(_underlying).safeTransfer(vault(), IERC20(_underlying).balanceOf(address(this)));
+    // Keep back whatever fee `_handleFee` could not pay out - it is below the dust floor,
+    // or the yield source refused the redemption. Handing it to the vault along with
+    // everything else would leave `pendingFee` with nothing behind it, and
+    // `investedUnderlyingBalance()` would then report less than zero.
+    uint256 balance = IERC20(_underlying).balanceOf(address(this));
+    uint256 fee = pendingFee();
+    if (balance > fee) {
+      IERC20(_underlying).safeTransfer(vault(), balance.sub(fee));
     }
     _updateStoredBalance();
   }
@@ -450,9 +466,11 @@ contract GeneralERC4626Strategy is BaseUpgradeableStrategy, IHardWorkHooks {
    * @return Total balance of underlying assets.
    */
   function investedUnderlyingBalance() public view returns (uint256) {
-    return IERC20(underlying()).balanceOf(address(this))
-    .add(storedBalance())
-    .sub(pendingFee());
+    uint256 total = IERC20(underlying()).balanceOf(address(this)).add(storedBalance());
+    uint256 fee = pendingFee();
+    // Clamped rather than subtracted outright: this is read by every vault entrypoint, so
+    // an underflow here would take deposits, withdrawals and the share price down with it.
+    return total > fee ? total.sub(fee) : 0;
   }
 
   /**

--- a/contracts/strategies/erc4626/GeneralERC4626Strategy.sol
+++ b/contracts/strategies/erc4626/GeneralERC4626Strategy.sol
@@ -88,6 +88,11 @@ contract GeneralERC4626Strategy is BaseUpgradeableStrategy, IHardWorkHooks {
    */
   function currentBalance() public view returns (uint256) {
     address _fToken = fToken();
+    // Marked GROSS, with `convertToAssets`. Any exit fee the yield source charges is
+    // deliberately left out of the share price and is instead borne by the user whose
+    // withdrawal actually triggers a redemption - see `_redeem`. A withdrawal the vault
+    // can serve from idle triggers none and pays none; that fee stays latent in the
+    // position until someone does redeem.
     uint256 underlyingBalance = IERC4626(_fToken).convertToAssets(IERC20(_fToken).balanceOf(address(this)));
     return underlyingBalance;
   }
@@ -491,15 +496,16 @@ contract GeneralERC4626Strategy is BaseUpgradeableStrategy, IHardWorkHooks {
    */
   function _redeem(uint256 amountUnderlying) internal {
     address _fToken = fToken();
-    // Redeem by SHARES, not by assets. `withdraw(assets)` delivers exactly
-    // `amountUnderlying` and takes any vault withdraw fee as extra shares on top, so the
-    // position drops by more than the strategy hands to the vault; VaultV1._withdraw then
-    // prices the exit off the reduced total and the withdrawer bears only a pro-rata slice
-    // of the fee, with the rest landing on every other holder. Burning exactly the shares
-    // worth `amountUnderlying` makes the fee come out of the delivered assets instead: the
-    // position drops by precisely what was asked, and the vault's `min(entitlement, idle)`
-    // charges the whole fee to the user withdrawing. On a fee-free vault the two differ
-    // only by rounding.
+    // Burn the shares worth `amountUnderlying` and take whatever the yield source pays for
+    // them. With the position marked gross, that delivers `amountUnderlying` less the exit
+    // fee, and `VaultV1._withdraw` hands the withdrawing user `min(entitlement, idle)` -
+    // so the shortfall is exactly the fee and it lands on them alone.
+    //
+    // NOT `withdraw(assets)`, which delivers the full amount and burns the fee as EXTRA
+    // shares on top: the position would fall by more than was paid out, the vault would
+    // reprice the exit off the reduced total, and the fee would spread over every holder.
+    // And not `previewWithdraw` either - grossing up would deliver the full entitlement
+    // and push the fee onto the holders who stay.
     uint256 shares = Math.min(
       IERC4626(_fToken).convertToShares(amountUnderlying),
       IERC20(_fToken).balanceOf(address(this))

--- a/contracts/strategies/erc4626/GeneralERC4626Strategy.sol
+++ b/contracts/strategies/erc4626/GeneralERC4626Strategy.sol
@@ -1,0 +1,543 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.26;
+
+import "@openzeppelin/contracts/utils/math/Math.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "../../base/interface/IUniversalLiquidator.sol";
+import "../../base/upgradability/BaseUpgradeableStrategy.sol";
+import "../../base/interface/IERC4626.sol";
+import "../../base/interface/IHardWorkHooks.sol";
+
+/**
+ * @title GeneralERC4626Strategy
+ * @dev A strategy that invests underlying assets into an ERC4626 compliant vault, providing yield and rewards.
+ */
+contract GeneralERC4626Strategy is BaseUpgradeableStrategy, IHardWorkHooks {
+
+  using SafeMath for uint256;
+  using SafeERC20 for IERC20;
+
+  /// @notice Emitted when a fee redemption was refused by the vault and left pending.
+  event FeeRedeemDeferred(uint256 amount);
+
+  address public constant harvestMSIG = address(0xF49440C1F012d041802b25A73e5B0B9166a75c02);
+
+  bytes32 internal constant _FTOKEN_SLOT = 0x462e4d44c9bae3e0ee3d71929710bef82ca7c929ce31980e75572ea415835b0e;
+  bytes32 internal constant _STORED_SUPPLIED_SLOT = 0x280539da846b4989609abdccfea039bd1453e4f710c670b29b9eeaca0730c1a2;
+  bytes32 internal constant _PENDING_FEE_SLOT = 0x0af7af9f5ccfa82c3497f40c7c382677637aee27293a6243a22216b51481bd97;
+
+  // this would be reset on each upgrade
+  address[] public rewardTokens;
+
+  struct Stream {
+    uint256 lastUpdate;     // last timestamp we updated unlocked accounting
+    uint256 periodFinish;   // end of current stream period
+    uint256 rate;          // tokens per second (truncated), in token's natural units
+
+    uint256 accounted;     // how many tokens are reserved/managed by the stream (locked+unlocked-not-yet-sold)
+    uint256 unlocked;      // unlocked amount accumulated since last sale (ready to sell)
+    uint256 duration;      // distribution duration (seconds). 0 disables streaming (sell all)
+  }
+
+  mapping(address => Stream) internal _stream;
+
+  constructor() BaseUpgradeableStrategy() {
+    assert(_FTOKEN_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.fToken")) - 1));
+    assert(_STORED_SUPPLIED_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.storedSupplied")) - 1));
+    assert(_PENDING_FEE_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.pendingFee")) - 1));
+  }
+
+  /**
+   * @notice Initializes the strategy and verifies compatibility with the ERC4626 vault.
+   * @param _storage Address of the storage contract.
+   * @param _underlying Address of the underlying asset.
+   * @param _vault Address of the vault.
+   * @param _fToken Address of the fToken (ERC4626 compliant vault token).
+   * @param _rewardToken Address of the reward token.
+   */
+  function initializeBaseStrategy(
+    address _storage,
+    address _underlying,
+    address _vault,
+    address _fToken,
+    address _rewardToken
+  )
+  public initializer {
+    BaseUpgradeableStrategy.initialize(
+      _storage,
+      _underlying,
+      _vault,
+      _fToken,
+      _rewardToken,
+      harvestMSIG
+    );
+
+    require(IERC4626(_fToken).asset() == _underlying, "Underlying mismatch");
+    _setFToken(_fToken);
+  }
+
+  function depositArbCheck() public pure returns (bool) {
+    // there's no arb here.
+    return true;
+  }
+
+  /**
+   * @notice Returns the current balance of assets in the strategy.
+   * @return Current balance of assets in underlying.
+   */
+  function currentBalance() public view returns (uint256) {
+    address _fToken = fToken();
+    uint256 underlyingBalance = IERC4626(_fToken).convertToAssets(IERC20(_fToken).balanceOf(address(this)));
+    return underlyingBalance;
+  }
+
+  /**
+   * @notice Returns the last stored balance of assets in the strategy.
+   * @return Stored balance of assets.
+   */
+  function storedBalance() public view returns (uint256) {
+    return getUint256(_STORED_SUPPLIED_SLOT);
+  }
+
+  /**
+   * @notice Updates the stored balance with the current balance.
+   */
+  function _updateStoredBalance() internal {
+    uint256 balance = currentBalance();
+    setUint256(_STORED_SUPPLIED_SLOT, balance);
+  }
+
+  /**
+   * @notice Calculates and returns the total fee numerator.
+   * @return Total fee numerator.
+   */
+  function totalFeeNumerator() public view returns (uint256) {
+    return strategistFeeNumerator().add(platformFeeNumerator()).add(profitSharingNumerator());
+  }
+
+  /**
+   * @notice Returns any accrued but unpaid fees.
+   * @return Pending fees.
+   */
+  function pendingFee() public view returns (uint256) {
+    return getUint256(_PENDING_FEE_SLOT);
+  }
+
+  /**
+   * @notice Accrues fees based on the increase in balance.
+   */
+  function _accrueFee() internal {
+    uint256 fee;
+    if (currentBalance() > storedBalance()) {
+      uint256 balanceIncrease = currentBalance().sub(storedBalance());
+      fee = balanceIncrease.mul(totalFeeNumerator()).div(feeDenominator());
+    }
+    setUint256(_PENDING_FEE_SLOT, pendingFee().add(fee));
+  }
+
+  /**
+   * @notice Processes any pending fees, redeems the fee amount, and sends to the controller.
+   */
+  function _handleFee() internal {
+    _accrueFee();
+    uint256 fee = pendingFee();
+    if (fee > 1e3) {
+      address _underlying = underlying();
+      uint256 availableBalance = IERC20(_underlying).balanceOf(address(this));
+      if (availableBalance < fee) {
+        address _fToken = fToken();
+        uint256 redeemable = Math.min(
+          fee.sub(availableBalance),
+          IERC4626(_fToken).maxWithdraw(address(this))
+        );
+        if (redeemable > 0) {
+          // The vault may refuse this redemption - a redemption delay, a withdrawal
+          // queue, or not enough instantly available liquidity. Leaving the fee in
+          // pendingFee and retrying on the next call is correct; reverting here would
+          // block doHardWork() and withdrawAllToVault() for everyone.
+          try IERC4626(_fToken).withdraw(redeemable, address(this), address(this)) returns (uint256) {
+          } catch {
+            emit FeeRedeemDeferred(redeemable);
+          }
+        }
+      }
+      fee = Math.min(fee, IERC20(_underlying).balanceOf(address(this)));
+      if (fee == 0) {
+        return;
+      }
+      uint256 balanceIncrease = fee.mul(feeDenominator()).div(totalFeeNumerator());
+      _notifyProfitInRewardToken(_underlying, balanceIncrease);
+      setUint256(_PENDING_FEE_SLOT, pendingFee().sub(fee));
+    }
+  }
+
+  /**
+   * @notice Determines if a token is unsalvageable (i.e., cannot be removed from the strategy).
+   * @param token Address of the token.
+   * @return Boolean indicating if the token is unsalvageable.
+   */
+  function unsalvagableTokens(address token) public view returns (bool) {
+    return (token == rewardToken() || token == underlying() || token == fToken());
+  }
+
+  /**
+   * @notice Invests the entire balance of underlying tokens into the lending pool.
+   */
+  function _investAllUnderlying() internal onlyNotPausedInvesting {
+    address _underlying = underlying();
+    uint256 underlyingBalance = IERC20(_underlying).balanceOf(address(this));
+    if (underlyingBalance > 1e3) {
+      _supply(underlyingBalance);
+    }
+  }
+
+  /**
+   * @notice Withdraws all assets from the strategy and transfers to the vault.
+   */
+  function withdrawAllToVault() public restricted {
+    _handleFee();
+    address _underlying = underlying();
+    _redeemAll();
+    if (IERC20(_underlying).balanceOf(address(this)) > 0) {
+      IERC20(_underlying).safeTransfer(vault(), IERC20(_underlying).balanceOf(address(this)));
+    }
+    _updateStoredBalance();
+  }
+
+  /**
+   * @notice Exits the strategy by redeeming all assets and pauses further investments.
+   */
+  function emergencyExit() external onlyGovernance {
+    _accrueFee();
+    _redeemAll();
+    _setPausedInvesting(true);
+    _updateStoredBalance();
+  }
+
+  /**
+   * @notice Resumes investing after being paused.
+   */
+  function continueInvesting() public onlyGovernance {
+    _setPausedInvesting(false);
+  }
+
+  /**
+   * @notice Withdraws a specified amount of underlying assets to the vault.
+   * @param amountUnderlying Amount of underlying assets to withdraw.
+   */
+  function withdrawToVault(uint256 amountUnderlying) public restricted {
+    _accrueFee();
+    address _underlying = underlying();
+    uint256 balance = IERC20(_underlying).balanceOf(address(this));
+    if (amountUnderlying <= balance) {
+      IERC20(_underlying).safeTransfer(vault(), amountUnderlying);
+      _updateStoredBalance();
+      return;
+    }
+    uint256 toRedeem = amountUnderlying.sub(balance);
+    _redeem(toRedeem);
+    balance = IERC20(_underlying).balanceOf(address(this));
+    IERC20(_underlying).safeTransfer(vault(), Math.min(amountUnderlying, balance));
+    // Any residue stays idle and is supplied by the next doHardWork(). Re-supplying it
+    // here would deposit into the vault immediately after redeeming from it, which some
+    // yield sources forbid.
+    _updateStoredBalance();
+  }
+
+    function addRewardToken(address _token) public onlyGovernance {
+    rewardTokens.push(_token);
+  }
+
+  function _liquidateRewards() internal {
+    if (!sell()) {
+      // Profits can be disabled for possible simplified and rapid exit
+      emit ProfitsNotCollected(sell(), false);
+      return;
+    }
+    address _rewardToken = rewardToken();
+    address _universalLiquidator = universalLiquidator();
+    for (uint256 i; i < rewardTokens.length; i++) {
+      address token = rewardTokens[i];
+      if (token == _rewardToken) continue;
+      _syncRewardStream(token);
+      uint256 toSell = _pullClaimable(token);
+      if (toSell > 1e3) {
+        IERC20(token).safeApprove(_universalLiquidator, 0);
+        IERC20(token).safeApprove(_universalLiquidator, toSell);
+        IUniversalLiquidator(_universalLiquidator).swap(token, _rewardToken, toSell, 1, address(this));
+      }
+    }
+    uint256 rewardBalance = IERC20(_rewardToken).balanceOf(address(this));
+    _notifyProfitInRewardToken(_rewardToken, rewardBalance);
+    uint256 remainingRewardBalance = IERC20(_rewardToken).balanceOf(address(this));
+
+    if (remainingRewardBalance <= 1e12) {
+      return;
+    }
+  
+    address _underlying = underlying();
+    if (_underlying != _rewardToken) {
+      IERC20(_rewardToken).safeApprove(_universalLiquidator, 0);
+      IERC20(_rewardToken).safeApprove(_universalLiquidator, remainingRewardBalance);
+      IUniversalLiquidator(_universalLiquidator).swap(_rewardToken, _underlying, remainingRewardBalance, 1, address(this));
+    }
+  }
+
+  function distributionTime(address token) public view returns (uint256) {
+    return _stream[token].duration;
+  }
+
+  function sellable(address token) public view returns (uint256) {
+    Stream memory stream = _stream[token];
+    if (stream.duration == 0) {
+      return IERC20(token).balanceOf(address(this));
+    }
+    uint256 unlockedAccrued = stream.unlocked;
+    uint256 last = stream.lastUpdate;
+    if (last == 0) return unlockedAccrued;
+
+    uint256 nowTs = block.timestamp;
+    uint256 effEnd = Math.min(nowTs, stream.periodFinish);
+    if (effEnd <= last) return unlockedAccrued;
+
+    uint256 dt = effEnd - last;
+    return unlockedAccrued + (dt * stream.rate);
+  }
+
+  function _accrueUnlocked(address token) internal {
+    Stream storage stream = _stream[token];
+    uint256 nowTs = block.timestamp;
+
+    uint256 last = stream.lastUpdate;
+    if (last == 0) {
+      stream.lastUpdate = nowTs;
+      return;
+    }
+
+    uint256 effEnd = Math.min(nowTs, uint256(stream.periodFinish));
+    if (effEnd <= last) {
+      return;
+    }
+
+    uint256 dt = effEnd - last;
+    uint256 unlockedNow = dt * uint256(stream.rate);
+
+    if (unlockedNow > 0) {
+      stream.unlocked += unlockedNow;
+    }
+
+    stream.lastUpdate = effEnd;
+  }
+
+  function _syncRewardStream(address token) internal {
+    Stream storage stream = _stream[token];
+    uint256 nowTs = block.timestamp;
+
+    // If streaming is disabled, we don't need to track anything.
+    if (stream.duration == 0) {
+      // keep accounting minimal: avoid stale accounted/unlocked causing confusion.
+      stream.accounted = 0;
+      stream.unlocked = 0;
+      stream.rate = 0;
+      stream.lastUpdate = nowTs;
+      stream.periodFinish = nowTs;
+      return;
+    }
+
+    _accrueUnlocked(token);
+
+    uint256 bal = IERC20(token).balanceOf(address(this));
+    uint256 accounted = stream.accounted;
+    uint256 newlyArrived = (bal > accounted) ? (bal - accounted) : 0;
+
+    if (newlyArrived == 0) {
+      return;
+    }
+
+    uint256 duration = stream.duration;
+
+    uint256 leftover = 0;
+    if (nowTs < uint256(stream.periodFinish)) {
+      uint256 remaining = uint256(stream.periodFinish) - nowTs;
+      leftover = remaining * uint256(stream.rate);
+    }
+
+    uint256 totalToStream = newlyArrived + leftover;
+    uint256 newRate = totalToStream / duration;
+
+    stream.rate = newRate;
+    stream.lastUpdate = nowTs;
+    stream.periodFinish = nowTs + duration;
+
+    // 4) Increase accounted by the newly arrived amount (we now manage it)
+    stream.accounted = accounted + newlyArrived;
+  }
+
+  function _pullClaimable(address token) internal returns (uint256 amount) {
+    Stream storage stream = _stream[token];
+
+    if (stream.duration == 0) {
+      amount = IERC20(token).balanceOf(address(this));
+      return amount;
+    }
+
+    _accrueUnlocked(token);
+
+    amount = stream.unlocked;
+    if (amount == 0) return 0;
+
+    uint256 bal = IERC20(token).balanceOf(address(this));
+    amount = Math.min(amount, bal);
+
+    stream.unlocked -= amount;
+
+    if (stream.accounted >= amount) {
+      stream.accounted -= amount;
+    } else {
+      // very defensive; should not happen unless token is weird (rebasing/fee-on-transfer)
+      stream.accounted = 0;
+    }
+  }
+
+  /**
+   * @notice Executes the main strategy logic including reward liquidation and reinvestment.
+   */
+  function doHardWork() public restricted {
+    _handleFee();
+    _liquidateRewards();
+    _investAllUnderlying();
+    _updateStoredBalance();
+  }
+
+  /**
+   * @notice Whether this strategy implements the optional hard work hooks.
+   * @return Always true.
+   */
+  function supportsHardWorkHooks() external pure returns (bool) {
+    return true;
+  }
+
+  /**
+   * @notice Hard work run inside a user's withdrawal transaction by a hook-aware vault.
+   * @dev Everything `doHardWork()` does to credit the exiting user - accrue the fee on
+   * the interest earned since the last call, liquidate rewards into underlying, and
+   * refresh `storedBalance` so `investedUnderlyingBalance()` reflects it - but without
+   * `_investAllUnderlying()`. Supplying here would deposit into the fToken immediately
+   * before the vault redeems from it, which the redemption delay forbids. Underlying
+   * left idle is still counted by `investedUnderlyingBalance()` and is supplied by the
+   * next `doHardWork()`.
+   */
+  function doHardWorkOnWithdraw() external restricted {
+    _handleFee();
+    _liquidateRewards();
+    _updateStoredBalance();
+  }
+
+  /**
+   * @notice Salvages a token that is not essential to the strategy's core operations.
+   * @param recipient Address to receive the salvaged tokens.
+   * @param token Address of the token to salvage.
+   * @param amount Amount of tokens to salvage.
+   */
+  function salvage(address recipient, address token, uint256 amount) public onlyGovernance {
+    require(!unsalvagableTokens(token), "Token is non-salvageable");
+    IERC20(token).safeTransfer(recipient, amount);
+  }
+
+  /**
+   * @notice Returns the total balance of underlying assets held by the strategy.
+   * @return Total balance of underlying assets.
+   */
+  function investedUnderlyingBalance() public view returns (uint256) {
+    return IERC20(underlying()).balanceOf(address(this))
+    .add(storedBalance())
+    .sub(pendingFee());
+  }
+
+  /**
+   * @notice Supplies a specified amount of underlying tokens to the lending pool.
+   * @param amount Amount of tokens to supply.
+   */
+  function _supply(uint256 amount) internal {
+    address _underlying = underlying();
+    address _fToken = fToken();
+    IERC20(_underlying).safeApprove(_fToken, 0);
+    IERC20(_underlying).safeApprove(_fToken, amount);
+    IERC4626(_fToken).deposit(amount, address(this));
+  }
+
+  /**
+   * @notice Redeems a specified amount of underlying tokens from the lending pool.
+   * @param amountUnderlying Amount of underlying tokens to redeem.
+   */
+  function _redeem(uint256 amountUnderlying) internal {
+    address _fToken = fToken();
+    // Redeem by SHARES, not by assets. `withdraw(assets)` delivers exactly
+    // `amountUnderlying` and takes any vault withdraw fee as extra shares on top, so the
+    // position drops by more than the strategy hands to the vault; VaultV1._withdraw then
+    // prices the exit off the reduced total and the withdrawer bears only a pro-rata slice
+    // of the fee, with the rest landing on every other holder. Burning exactly the shares
+    // worth `amountUnderlying` makes the fee come out of the delivered assets instead: the
+    // position drops by precisely what was asked, and the vault's `min(entitlement, idle)`
+    // charges the whole fee to the user withdrawing. On a fee-free vault the two differ
+    // only by rounding.
+    uint256 shares = Math.min(
+      IERC4626(_fToken).convertToShares(amountUnderlying),
+      IERC20(_fToken).balanceOf(address(this))
+    );
+    if (shares == 0) {
+      return;
+    }
+    IERC4626(_fToken).redeem(shares, address(this), address(this));
+  }
+
+  /**
+   * @notice Redeems all assets from the lending pool.
+   */
+  function _redeemAll() internal {
+    address _fToken = fToken();
+    if (IERC20(_fToken).balanceOf(address(this)) > 0) {
+      IERC4626(_fToken).redeem(
+        IERC20(_fToken).balanceOf(address(this)),
+        address(this),
+        address(this)
+      );
+    }
+  }
+
+  /**
+   * @notice Sets the address of the fToken.
+   * @param _target Address of the fToken.
+   */
+  function _setFToken (address _target) internal {
+    setAddress(_FTOKEN_SLOT, _target);
+  }
+
+  /**
+   * @notice Returns the address of the fToken.
+   * @return Address of the fToken.
+   */
+  function fToken() public view returns (address) {
+    return getAddress(_FTOKEN_SLOT);
+  }
+
+  function _setDistributionTime(address token, uint256 duration) internal {
+    require(duration == 0 || duration > 10, "duration > 10 || 0");
+    _stream[token].duration = duration;
+  }
+
+  function setDistributionTime(address token, uint256 duration) external onlyGovernance {
+    _setDistributionTime(token, duration);
+  }
+
+
+  /**
+   * @notice Finalizes the upgrade of the strategy.
+   */
+  function finalizeUpgrade() external virtual onlyGovernance {
+    _finalizeUpgrade();
+  }
+
+  receive() external payable {}
+}

--- a/contracts/strategies/erc4626/IPORLendingStrategyMainnet_BTCdc.sol
+++ b/contracts/strategies/erc4626/IPORLendingStrategyMainnet_BTCdc.sol
@@ -1,0 +1,25 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.26;
+
+import "./GeneralERC4626Strategy.sol";
+
+contract IPORLendingStrategyMainnet_BTCdc is GeneralERC4626Strategy {
+
+  constructor() {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599);
+    address fToken = address(0x7659fc26bf3A63E8133BbECB7E16ACD48EE8E292);
+    address weth = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    GeneralERC4626Strategy.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      fToken,
+      weth
+    );
+  }
+}

--- a/contracts/strategies/erc4626/IPORLendingStrategyMainnet_bdUSD.sol
+++ b/contracts/strategies/erc4626/IPORLendingStrategyMainnet_bdUSD.sol
@@ -1,0 +1,25 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.26;
+
+import "./GeneralERC4626Strategy.sol";
+
+contract IPORLendingStrategyMainnet_bdUSD is GeneralERC4626Strategy {
+
+  constructor() {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+    address fToken = address(0xF8F226dA66244F89e70C5B5D1a5C5b0d505Eb1d8);
+    address weth = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    GeneralERC4626Strategy.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      fToken,
+      weth
+    );
+  }
+}

--- a/test/erc4626/ipor-bdusd.js
+++ b/test/erc4626/ipor-bdusd.js
@@ -195,6 +195,46 @@ describe("Mainnet IPOR Lending bdUSD", function () {
       assert.isTrue(got >= entitlement * (1 - fee) * ipor * (1 - 1e-4), "the withdrawer was charged more than the exit fee");
     });
 
+    it("leaves the fee latent - and unpaid - for an exit served entirely from idle", async function () {
+      // Deliberate policy, pinned here so a change to it is visible: the position is marked
+      // GROSS, so the exit fee is charged only to the user whose withdrawal actually
+      // triggers a redemption. A withdrawal the vault can serve out of idle underlying
+      // triggers none, so that user pays nothing and the fee stays latent in the position
+      // for whoever redeems next. Marking net (previewRedeem) would instead take the
+      // haircut into the share price at investment time, charging every holder up front.
+      await deploy();
+      await fund(farmer1, "50000000000");
+      await fund(farmer2, "50000000000");
+      await depositVault(farmer1, underlying, vault, "50000000000");
+      await controller.doHardWork(vault.address, { from: governance }); // farmer1 goes in
+      await network.provider.send("evm_mine");
+      await depositVault(farmer2, underlying, vault, "50000000000");    // farmer2 stays idle
+
+      const idle = num(await vault.underlyingBalanceInVault());
+      const entitlement1 = num(await vault.underlyingBalanceWithInvestmentForHolder(farmer1));
+      assert.isTrue(entitlement1 <= idle, "precondition: the exit must be servable without redeeming");
+      const heldShares = new BigNumber(await fTokenErc20.balanceOf(strategy.address)).toFixed();
+      const latent = num(await fToken.convertToAssets(heldShares)) - num(await fToken.previewRedeem(heldShares));
+      console.log("  vault idle", idle, "| farmer1 entitlement", entitlement1, "| latent fee in the position", latent);
+      assert.isTrue(latent > 0, "precondition: the position must carry an exit fee");
+
+      const before1 = num(await underlying.balanceOf(farmer1));
+      await vault.withdraw((await vault.balanceOf(farmer1)).toString(), { from: farmer1 });
+      const got1 = num(await underlying.balanceOf(farmer1)) - before1;
+      console.log("  farmer1 received", got1, "of a", entitlement1, "entitlement - fee paid:", entitlement1 - got1);
+
+      // No redemption, so no fee - the gross mark is what makes this true.
+      assert.isTrue(got1 >= entitlement1 * (1 - 1e-6), "an exit needing no redemption must pay no exit fee");
+      // The fee did not vanish: it is still sitting in the position farmer2 now owns, and
+      // farmer2 pays it when they redeem.
+      const before2 = num(await underlying.balanceOf(farmer2));
+      const entitlement2 = num(await vault.underlyingBalanceWithInvestmentForHolder(farmer2));
+      await vault.withdraw((await vault.balanceOf(farmer2)).toString(), { from: farmer2 });
+      const got2 = num(await underlying.balanceOf(farmer2)) - before2;
+      console.log("  farmer2 received", got2, "of a", entitlement2, "entitlement - fee paid:", entitlement2 - got2);
+      assert.isTrue(entitlement2 - got2 >= latent * 0.99, "the deferred fee must land on the holder who does redeem");
+    });
+
     it("still attributes it when the exit is served from vault idle plus a redeem", async function () {
       // The previous test exits a fully invested vault. Here 30% sits idle in the vault and
       // the exiter holds 50% of supply, so the payout is part idle and part fresh redemption

--- a/test/erc4626/ipor-bdusd.js
+++ b/test/erc4626/ipor-bdusd.js
@@ -1,0 +1,192 @@
+// IPOR Fusion bdUSD (USDC) on Ethereum, through HookVaultV2 + GeneralERC4626Strategy.
+//
+// bdUSD charges an off-boarding fee on every redemption (0.20% at the pinned block). The
+// strategy redeems by shares so that fee comes out of the withdrawing user's own payout and
+// is never socialised across the other holders - the second test pins that down.
+//
+// On a fork nothing rebalances the PlasmaVault, so its cached market balances do not
+// accrue with simulated time. The happy path therefore does not assert "farmer earns
+// money"; it asserts the stronger, fork-proof property that a farmer going through the
+// Harvest vault ends up with what a depositor going straight into the PlasmaVault gets,
+// minus only Harvest's fee on any profit.
+//
+// Developed and tested at blockNumber 25933440
+
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const BigNumber = require("bignumber.js");
+const { ethers, network } = require("hardhat");
+
+const IERC20 = artifacts.require("IERC20");
+const IERC4626 = artifacts.require("contracts/base/interface/IERC4626.sol:IERC4626");
+const HookVaultV2 = artifacts.require("HookVaultV2");
+const Strategy = artifacts.require("IPORLendingStrategyMainnet_bdUSD");
+
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const USDC_BALANCES_SLOT = 9;
+const FTOKEN = "0xF8F226dA66244F89e70C5B5D1a5C5b0d505Eb1d8";
+
+describe("Mainnet IPOR Lending bdUSD", function () {
+  let accounts, governance, farmer1, farmer2, reference;
+  let underlying, fToken, fTokenErc20;
+  let controller, vault, strategy;
+
+  // Write straight into USDC's balances mapping - no whale needed.
+  async function fund(who, amount) {
+    const key = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(["address", "uint256"], [who, USDC_BALANCES_SLOT]));
+    await network.provider.send("hardhat_setStorageAt", [USDC, key, ethers.utils.hexZeroPad(ethers.BigNumber.from(amount).toHexString(), 32)]);
+  }
+
+  // Ratios are done in plain numbers: Utils.js configures bignumber.js with DECIMAL_PLACES 0,
+  // so a fractional BigNumber division rounds to an integer. Every value here is < 2^53.
+  const num = (x) => Number(new BigNumber(x).toFixed());
+
+  // The PlasmaVault's own exit fee, measured: previewRedeem is net of it, convertToAssets is not.
+  async function iporExitFee() {
+    const probe = "1000000000000";
+    const gross = num(await fToken.convertToAssets(probe));
+    const net = num(await fToken.previewRedeem(probe));
+    return (gross - net) / gross;
+  }
+
+  // Share price at full precision; getPricePerFullShare() is truncated to the underlying's decimals.
+  async function pricePerShare() {
+    return num(await vault.underlyingBalanceWithInvestment()) / num(await vault.totalSupply());
+  }
+
+  before(async function () {
+    governance = addresses.Governance;
+    accounts = await web3.eth.getAccounts();
+    farmer1 = accounts[1];
+    farmer2 = accounts[2];
+    reference = accounts[3];
+
+    await impersonates([governance]);
+    await web3.eth.sendTransaction({ from: accounts[9], to: governance, value: 10e18 });
+
+    underlying = await IERC20.at(USDC);
+    fToken = await IERC4626.at(FTOKEN);
+    fTokenErc20 = await IERC20.at(FTOKEN);
+    console.log("Fetching Underlying at: ", underlying.address);
+
+    const vaultImpl = await HookVaultV2.new({ from: governance });
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "vaultImplementationOverride": vaultImpl.address,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+    vault = await HookVaultV2.at(vault.address);
+
+    await fund(farmer1, "90000000000");   // 90,000 USDC
+    await fund(farmer2, "10000000000");   // 10,000 USDC
+    await fund(reference, "90000000000");
+  });
+
+  describe("Happy path", function () {
+    it("Farmer gets what a direct PlasmaVault depositor gets, minus only Harvest's fee on profit", async function () {
+      const principal = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, principal.toFixed());
+
+      // The reference enters the PlasmaVault in the same block the strategy does (the
+      // first hard work is what deploys the deposit).
+      await underlying.approve(FTOKEN, principal.toFixed(), { from: reference });
+      await fToken.deposit(principal.toFixed(), reference, { from: reference });
+
+      let hours = 10;
+      let blocksPerHour = 2400;
+      let oldSharePrice;
+      let newSharePrice;
+
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+
+      // The PlasmaVault keeps a redeemer's exit fee, so whoever redeems second collects a
+      // slice of the first one's fee. Measure the two exits from the same state.
+      const snapshot = await network.provider.send("evm_snapshot");
+      await fToken.redeem(new BigNumber(await fTokenErc20.balanceOf(reference)).toFixed(), reference, reference, { from: reference });
+      const referenceGot = new BigNumber(await underlying.balanceOf(reference));
+      await network.provider.send("evm_revert", [snapshot]);
+
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      const farmerGot = new BigNumber(await underlying.balanceOf(farmer1));
+
+      const gain = BigNumber.max(referenceGot.minus(principal), 0);
+      const harvestFee = gain
+        .times(await strategy.totalFeeNumerator())
+        .idiv(await strategy.feeDenominator())
+        .plus(1);
+
+      console.log("principal      ", principal.toFixed());
+      console.log("via Harvest    ", farmerGot.toFixed());
+      console.log("direct to IPOR ", referenceGot.toFixed(), "(Harvest fee on the profit:", harvestFee.toFixed() + ")");
+      console.log("difference     ", farmerGot.minus(referenceGot).toFixed());
+
+      // Rounding: a couple of units across two share conversions and the exit fee.
+      const rounding = referenceGot.idiv(1000000).plus(1);
+      Utils.assertBNGte(farmerGot, referenceGot.minus(harvestFee).minus(rounding));
+      // And the wrapper never gives away more than IPOR does.
+      Utils.assertBNGte(referenceGot.plus(rounding), farmerGot);
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+
+  describe("Exit fee attribution", function () {
+    it("charges the PlasmaVault's exit fee to the withdrawing user only", async function () {
+      await depositVault(farmer1, underlying, vault, new BigNumber(await underlying.balanceOf(farmer1)).toFixed());
+      await depositVault(farmer2, underlying, vault, new BigNumber(await underlying.balanceOf(farmer2)).toFixed());
+      await controller.doHardWork(vault.address, { from: governance });
+      await network.provider.send("evm_mine"); // clear the redemption lock the deposit armed
+
+      const fee = await iporExitFee();
+      const probe = "1000000000000";
+      const iporPps0 = num(await fToken.convertToAssets(probe));
+      const pps0 = await pricePerShare();
+      const entitlement = num(await vault.underlyingBalanceWithInvestmentForHolder(farmer2));
+      const shares = new BigNumber(await vault.balanceOf(farmer2)).toFixed();
+      console.log("  IPOR exit fee      ", (fee * 100).toFixed(4) + "%");
+      console.log("  farmer2 entitlement", entitlement);
+
+      const before = num(await underlying.balanceOf(farmer2));
+      await vault.withdraw(shares, { from: farmer2 });
+      const got = num(await underlying.balanceOf(farmer2)) - before;
+
+      const pps1 = await pricePerShare();
+      const iporPps1 = num(await fToken.convertToAssets(probe));
+      const ipor = iporPps1 / iporPps0;
+      const bystander = pps1 / pps0;
+      // The PlasmaVault refreshes its market balances on a redemption. Whatever that does
+      // to its own share price legitimately reaches every Harvest holder (net of Harvest's
+      // fee on a gain); the exit fee must not.
+      const totalFee = num(await strategy.totalFeeNumerator()) / num(await strategy.feeDenominator());
+      const expected = ipor > 1 ? 1 + (ipor - 1) * (1 - totalFee) : ipor;
+
+      console.log("  farmer2 received   ", got, "=", (got / entitlement * 100).toFixed(4) + "% of entitlement");
+      console.log("  IPOR pps ratio     ", ipor.toFixed(8));
+      console.log("  bystander pps ratio", bystander.toFixed(8), "(expected >=", expected.toFixed(8) + ")");
+
+      // Socialising the fee would cost the bystanders fee x farmer2's share of supply
+      // (~0.02% here); the tolerance is an order of magnitude below that.
+      assert.isTrue(bystander >= expected * (1 - 2e-5), "the exit fee leaked onto the remaining holders");
+      // The withdrawer paid the fee, and nothing beyond the fee and IPOR's own revaluation.
+      assert.isTrue(got <= entitlement * (1 - fee) * (1 + 1e-4), "the withdrawer did not pay the exit fee");
+      assert.isTrue(got >= entitlement * (1 - fee) * ipor * (1 - 1e-4), "the withdrawer was charged more than the exit fee");
+    });
+  });
+});

--- a/test/erc4626/ipor-bdusd.js
+++ b/test/erc4626/ipor-bdusd.js
@@ -56,6 +56,21 @@ describe("Mainnet IPOR Lending bdUSD", function () {
     return num(await vault.underlyingBalanceWithInvestment()) / num(await vault.totalSupply());
   }
 
+  // A fresh vault and strategy. Each group of tests that changes the vault's configuration
+  // or drains it takes its own, so the groups do not depend on each other's leftovers.
+  async function deploy() {
+    const vaultImpl = await HookVaultV2.new({ from: governance });
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "vaultImplementationOverride": vaultImpl.address,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+    vault = await HookVaultV2.at(vault.address);
+  }
+
   before(async function () {
     governance = addresses.Governance;
     accounts = await web3.eth.getAccounts();
@@ -71,16 +86,7 @@ describe("Mainnet IPOR Lending bdUSD", function () {
     fTokenErc20 = await IERC20.at(FTOKEN);
     console.log("Fetching Underlying at: ", underlying.address);
 
-    const vaultImpl = await HookVaultV2.new({ from: governance });
-    [controller, vault, strategy] = await setupCoreProtocol({
-      "existingVaultAddress": null,
-      "vaultImplementationOverride": vaultImpl.address,
-      "strategyArtifact": Strategy,
-      "strategyArtifactIsUpgradable": true,
-      "underlying": underlying,
-      "governance": governance,
-    });
-    vault = await HookVaultV2.at(vault.address);
+    await deploy();
 
     await fund(farmer1, "90000000000");   // 90,000 USDC
     await fund(farmer2, "10000000000");   // 10,000 USDC
@@ -187,6 +193,47 @@ describe("Mainnet IPOR Lending bdUSD", function () {
       // The withdrawer paid the fee, and nothing beyond the fee and IPOR's own revaluation.
       assert.isTrue(got <= entitlement * (1 - fee) * (1 + 1e-4), "the withdrawer did not pay the exit fee");
       assert.isTrue(got >= entitlement * (1 - fee) * ipor * (1 - 1e-4), "the withdrawer was charged more than the exit fee");
+    });
+
+    it("still attributes it when the exit is served from vault idle plus a redeem", async function () {
+      // The previous test exits a fully invested vault. Here 30% sits idle in the vault and
+      // the exiter holds 50% of supply, so the payout is part idle and part fresh redemption
+      // and the vault's min(entitlement, idle) has to bind on the entitlement for the fee to
+      // stay with the withdrawer.
+      await deploy();
+      await vault.setVaultFractionToInvest(70, 100, { from: governance });
+      await fund(farmer1, "50000000000");
+      await fund(farmer2, "50000000000");
+      await depositVault(farmer1, underlying, vault, "50000000000");
+      await depositVault(farmer2, underlying, vault, "50000000000");
+      await controller.doHardWork(vault.address, { from: governance });
+      await network.provider.send("evm_mine");
+
+      const idle = num(await vault.underlyingBalanceInVault());
+      const entitlement = num(await vault.underlyingBalanceWithInvestmentForHolder(farmer2));
+      assert.isTrue(entitlement > idle, "precondition: the exit must need a redemption too");
+      console.log("  vault idle", idle, "| entitlement", entitlement);
+
+      const fee = await iporExitFee();
+      const probe = "1000000000000";
+      const iporPps0 = num(await fToken.convertToAssets(probe));
+      const pps0 = await pricePerShare();
+      const before = num(await underlying.balanceOf(farmer2));
+      await vault.withdraw((await vault.balanceOf(farmer2)).toString(), { from: farmer2 });
+      const got = num(await underlying.balanceOf(farmer2)) - before;
+      const ipor = num(await fToken.convertToAssets(probe)) / iporPps0;
+      const bystander = (await pricePerShare()) / pps0;
+
+      // Only the redeemed part carries a fee, so the exiter's shortfall is fee x (what was
+      // redeemed), not fee x entitlement.
+      const redeemed = entitlement - idle;
+      console.log("  redeemed", redeemed, "| fee on it", Math.round(fee * redeemed), "| exiter paid", entitlement - got);
+      console.log("  ipor pps ratio", ipor.toFixed(8), "bystander pps ratio", bystander.toFixed(8));
+
+      const totalFee = num(await strategy.totalFeeNumerator()) / num(await strategy.feeDenominator());
+      const expected = ipor > 1 ? 1 + (ipor - 1) * (1 - totalFee) : ipor;
+      assert.isTrue(bystander >= expected * (1 - 2e-5), "the exit fee leaked onto the remaining holders");
+      assert.isTrue(entitlement - got >= fee * redeemed * 0.99, "the withdrawer did not pay the fee on what was redeemed");
     });
   });
 });

--- a/test/erc4626/ipor-bdusd.js
+++ b/test/erc4626/ipor-bdusd.js
@@ -153,8 +153,108 @@ describe("Mainnet IPOR Lending bdUSD", function () {
     });
   });
 
+  describe("Performance fee high water mark", function () {
+    let sink;
+
+    // Move PlasmaVault shares in and out of the strategy to simulate the position losing
+    // and regaining value. The PlasmaVault caches its market balances, so simulated time
+    // does not move `currentBalance()` on a fork; moving shares does, deterministically,
+    // and is what a NAV change looks like to the strategy.
+    async function moveShares(from, to, shares) {
+      await impersonates([from]);
+      await web3.eth.sendTransaction({ from: accounts[9], to: from, value: 1e18 });
+      await fTokenErc20.transfer(to, shares, { from: from });
+      await network.provider.send("evm_mine"); // a transfer arms the redemption lock
+    }
+
+    before(async function () {
+      await deploy();
+      sink = accounts[8];
+      await fund(farmer1, "90000000000");
+      await depositVault(farmer1, underlying, vault, "90000000000");
+      await controller.doHardWork(vault.address, { from: governance });
+      await network.provider.send("evm_mine");
+      await strategy.doHardWork({ from: governance }); // settle any fee from going in
+    });
+
+    it("charges the fee on a gain", async function () {
+      const before = num(await strategy.pendingFee());
+      const gain = num(await strategy.currentBalance()) * 0.02;
+      await fund(reference, "5000000000");
+      await underlying.approve(FTOKEN, String(Math.round(gain)), { from: reference });
+      await fToken.deposit(String(Math.round(gain)), strategy.address, { from: reference });
+      await network.provider.send("evm_mine");
+
+      await strategy.doHardWork({ from: governance });
+      console.log("  pendingFee", before, "->", num(await strategy.pendingFee()), "| lossCarry", num(await strategy.lossCarry()));
+      assert.equal(num(await strategy.lossCarry()), 0, "a gain must not create a loss carry");
+    });
+
+    it("records a loss instead of charging anything, then waives the fee on earning it back", async function () {
+      const peak = num(await strategy.currentBalance());
+      const heldShares = new BigNumber(await fTokenErc20.balanceOf(strategy.address));
+      const moved = heldShares.idiv(20).toFixed(); // ~5% of the position
+
+      // --- the dip ---
+      await moveShares(strategy.address, sink, moved);
+      const dipped = num(await strategy.currentBalance());
+      const feeBeforeDip = num(await strategy.pendingFee());
+      await strategy.doHardWork({ from: governance });
+      const carry = num(await strategy.lossCarry());
+      console.log("  position", peak, "->", dipped, "| lossCarry", carry, "| pendingFee", feeBeforeDip, "->", num(await strategy.pendingFee()));
+      assert.isTrue(carry > 0, "the loss must be carried");
+      assert.approximately(carry / (peak - dipped), 1, 0.01, "the whole loss must be carried");
+      assert.equal(num(await strategy.pendingFee()), feeBeforeDip, "a loss must not accrue a fee");
+
+      // --- earning it back: this is what a snapshot mark would charge for ---
+      const feeBeforeRecovery = num(await strategy.pendingFee());
+      const keptBefore = num(await strategy.investedUnderlyingBalance());
+      const valueBefore = num(await strategy.currentBalance());
+      await moveShares(sink, strategy.address, moved);
+      const recoveredValue = num(await strategy.currentBalance()) - valueBefore;
+      await strategy.doHardWork({ from: governance });
+      const keptOnRecovery = num(await strategy.investedUnderlyingBalance()) - keptBefore;
+      const feeAfterRecovery = num(await strategy.pendingFee());
+      const carryAfter = num(await strategy.lossCarry());
+      const wouldHaveBeen = (peak - dipped) * num(await strategy.totalFeeNumerator()) / num(await strategy.feeDenominator());
+      console.log("  recovered: pendingFee", feeBeforeRecovery, "->", feeAfterRecovery,
+                  "| lossCarry", carry, "->", carryAfter, "| a snapshot mark would have charged ~", Math.round(wouldHaveBeen));
+      assert.isTrue(carryAfter < carry * 0.02, "the recovery must clear the carry");
+      assert.isTrue(feeAfterRecovery - feeBeforeRecovery < wouldHaveBeen * 0.02,
+        "no fee is due for a recovery back to the previous high water mark");
+      // The mirror of the next test: depositors keep the whole recovery, not 1 - rate of it.
+      console.log("  depositors kept", keptOnRecovery, "of a", Math.round(recoveredValue), "recovery =",
+                  (keptOnRecovery / recoveredValue * 100).toFixed(2) + "%");
+      assert.approximately(keptOnRecovery / recoveredValue, 1, 0.01,
+        "depositors must keep the whole recovery");
+    });
+
+    it("charges again once the position is past its previous peak", async function () {
+      assert.isTrue(num(await strategy.lossCarry()) < 1e3, "precondition: the carry must be spent");
+      const rate = num(await strategy.totalFeeNumerator()) / num(await strategy.feeDenominator());
+
+      const before = num(await strategy.investedUnderlyingBalance());
+      const gain = Math.round(num(await strategy.currentBalance()) * 0.02);
+      await fund(reference, "5000000000");
+      await underlying.approve(FTOKEN, String(gain), { from: reference });
+      await fToken.deposit(String(gain), strategy.address, { from: reference });
+      await network.provider.send("evm_mine");
+      await strategy.doHardWork({ from: governance });
+      const kept = num(await strategy.investedUnderlyingBalance()) - before;
+
+      console.log("  gain past the peak", gain, "| depositors kept", kept,
+                  "=", (kept / gain * 100).toFixed(2) + "% (fee rate", (rate * 100).toFixed(0) + "%)");
+      assert.equal(num(await strategy.lossCarry()), 0, "a gain must not create a carry");
+      // Above the high water mark the fee is live again, so depositors keep 1 - rate of it.
+      assert.approximately(kept / gain, 1 - rate, 0.01, "a new-high gain must be charged the fee");
+    });
+  });
+
   describe("Exit fee attribution", function () {
     it("charges the PlasmaVault's exit fee to the withdrawing user only", async function () {
+      await deploy();
+      await fund(farmer1, "90000000000");
+      await fund(farmer2, "10000000000");
       await depositVault(farmer1, underlying, vault, new BigNumber(await underlying.balanceOf(farmer1)).toFixed());
       await depositVault(farmer2, underlying, vault, new BigNumber(await underlying.balanceOf(farmer2)).toFixed());
       await controller.doHardWork(vault.address, { from: governance });

--- a/test/erc4626/ipor-btcdc.js
+++ b/test/erc4626/ipor-btcdc.js
@@ -56,6 +56,21 @@ describe("Mainnet IPOR Lending BTCdc", function () {
     return num(await vault.underlyingBalanceWithInvestment()) / num(await vault.totalSupply());
   }
 
+  // A fresh vault and strategy. Each group of tests that changes the vault's configuration
+  // or drains it takes its own, so the groups do not depend on each other's leftovers.
+  async function deploy() {
+    const vaultImpl = await HookVaultV2.new({ from: governance });
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "vaultImplementationOverride": vaultImpl.address,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+    vault = await HookVaultV2.at(vault.address);
+  }
+
   before(async function () {
     governance = addresses.Governance;
     accounts = await web3.eth.getAccounts();
@@ -71,16 +86,7 @@ describe("Mainnet IPOR Lending BTCdc", function () {
     fTokenErc20 = await IERC20.at(FTOKEN);
     console.log("Fetching Underlying at: ", underlying.address);
 
-    const vaultImpl = await HookVaultV2.new({ from: governance });
-    [controller, vault, strategy] = await setupCoreProtocol({
-      "existingVaultAddress": null,
-      "vaultImplementationOverride": vaultImpl.address,
-      "strategyArtifact": Strategy,
-      "strategyArtifactIsUpgradable": true,
-      "underlying": underlying,
-      "governance": governance,
-    });
-    vault = await HookVaultV2.at(vault.address);
+    await deploy();
 
     await fund(farmer1, "90000000");   // 0.9 WBTC
     await fund(farmer2, "10000000");   // 0.1 WBTC
@@ -187,6 +193,90 @@ describe("Mainnet IPOR Lending BTCdc", function () {
       // The withdrawer paid the fee, and nothing beyond the fee and IPOR's own revaluation.
       assert.isTrue(got <= entitlement * (1 - fee) * (1 + 1e-4), "the withdrawer did not pay the exit fee");
       assert.isTrue(got >= entitlement * (1 - fee) * ipor * (1 - 1e-4), "the withdrawer was charged more than the exit fee");
+    });
+  });
+  describe("Fee handling", function () {
+    // A position increase that is small enough for the accrued fee to fall under
+    // _handleFee's 1e3 dust floor. On 8-decimal WBTC that is only ~6,700 sat of gain, so
+    // it is an ordinary inter-harvest move rather than a corner case.
+    async function accrueDustFee() {
+      const numerator = num(await strategy.totalFeeNumerator());
+      const denominator = num(await strategy.feeDenominator());
+      // Sized off whatever gap is already there, so the accrued fee lands comfortably under
+      // the 1e3 floor regardless of what the PlasmaVault's last refresh did.
+      const gap = Math.max(num(await strategy.currentBalance()) - num(await strategy.storedBalance()), 0);
+      const increase = Math.max(Math.floor(500 * denominator / numerator) - gap, 0);
+      if (increase > 0) {
+        await underlying.approve(FTOKEN, String(increase), { from: reference });
+        await fToken.deposit(String(increase), strategy.address, { from: reference });
+        await network.provider.send("evm_mine"); // clear the lock the donation armed
+      }
+      await strategy.doHardWork({ from: governance });
+      return num(await strategy.pendingFee());
+    }
+
+    it("a full exit still works when the accrued fee is below the dust floor", async function () {
+      await fund(farmer1, "90000000");
+      await fund(reference, "90000000");
+      await depositVault(farmer1, underlying, vault, "90000000");
+      await controller.doHardWork(vault.address, { from: governance });
+      await network.provider.send("evm_mine");
+
+      const dust = await accrueDustFee();
+      console.log("  pendingFee below the dust floor:", dust);
+      assert.isTrue(dust > 0 && dust <= 1000, "precondition: an unpayable dust fee must be pending, got " + dust);
+
+      // The whole supply leaves, so the vault drains the strategy completely. The fee has
+      // to stay behind it, or investedUnderlyingBalance() underflows and the exit reverts.
+      const before = num(await underlying.balanceOf(farmer1));
+      await vault.withdraw((await vault.balanceOf(farmer1)).toString(), { from: farmer1 });
+      const got = num(await underlying.balanceOf(farmer1)) - before;
+      console.log("  farmer1 exited with", got, "| strategy reports", num(await strategy.investedUnderlyingBalance()));
+
+      assert.isTrue(got > 0, "the sole holder must be able to exit");
+      assert.equal((await vault.balanceOf(farmer1)).toString(), "0");
+      assert.equal(num(await strategy.investedUnderlyingBalance()), 0);
+      // And the vault is still usable afterwards, rather than reverting on every view.
+      assert.isTrue(num(await vault.getPricePerFullShare()) > 0);
+    });
+
+    it("governance draining the strategy leaves the vault usable", async function () {
+      await fund(farmer1, "90000000");
+      await fund(reference, "90000000");
+      await depositVault(farmer1, underlying, vault, "90000000");
+      await controller.doHardWork(vault.address, { from: governance });
+      await network.provider.send("evm_mine");
+      const dust = await accrueDustFee();
+      console.log("  pendingFee below the dust floor:", dust);
+      assert.isTrue(dust > 0 && dust <= 1000, "precondition: an unpayable dust fee must be pending, got " + dust);
+
+      await vault.withdrawAll({ from: governance });
+      console.log("  after withdrawAll - strategy idle", num(await underlying.balanceOf(strategy.address)),
+                  "pendingFee", num(await strategy.pendingFee()),
+                  "reported", num(await strategy.investedUnderlyingBalance()));
+      assert.isTrue(num(await vault.getPricePerFullShare()) > 0, "share price must not revert after a drain");
+
+      const before = num(await underlying.balanceOf(farmer1));
+      await vault.withdraw((await vault.balanceOf(farmer1)).toString(), { from: farmer1 });
+      assert.isTrue(num(await underlying.balanceOf(farmer1)) > before, "holders must still be able to exit");
+    });
+
+    it("forwards a payable fee to the reward forwarder", async function () {
+      await fund(farmer1, "90000000");
+      await fund(reference, "90000000");
+      await depositVault(farmer1, underlying, vault, "90000000");
+      await controller.doHardWork(vault.address, { from: governance });
+      await network.provider.send("evm_mine");
+
+      // Well above the dust floor, so _handleFee redeems it and hands it to the forwarder.
+      await underlying.approve(FTOKEN, "1000000", { from: reference });
+      await fToken.deposit("1000000", strategy.address, { from: reference });
+      await network.provider.send("evm_mine");
+
+      await strategy.doHardWork({ from: governance });
+      const pending = num(await strategy.pendingFee());
+      console.log("  pendingFee after the harvest:", pending);
+      assert.isTrue(pending <= 1000, "the fee must have been paid out, not left pending");
     });
   });
 });

--- a/test/erc4626/ipor-btcdc.js
+++ b/test/erc4626/ipor-btcdc.js
@@ -1,0 +1,192 @@
+// IPOR Fusion BTCdc (WBTC) on Ethereum, through HookVaultV2 + GeneralERC4626Strategy.
+//
+// BTCdc charges an off-boarding fee on every redemption (0.10% at the pinned block). The
+// strategy redeems by shares so that fee comes out of the withdrawing user's own payout and
+// is never socialised across the other holders - the second test pins that down.
+//
+// On a fork nothing rebalances the PlasmaVault, so its cached market balances do not
+// accrue with simulated time. The happy path therefore does not assert "farmer earns
+// money"; it asserts the stronger, fork-proof property that a farmer going through the
+// Harvest vault ends up with what a depositor going straight into the PlasmaVault gets,
+// minus only Harvest's fee on any profit.
+//
+// Developed and tested at blockNumber 25933440
+
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const BigNumber = require("bignumber.js");
+const { ethers, network } = require("hardhat");
+
+const IERC20 = artifacts.require("IERC20");
+const IERC4626 = artifacts.require("contracts/base/interface/IERC4626.sol:IERC4626");
+const HookVaultV2 = artifacts.require("HookVaultV2");
+const Strategy = artifacts.require("IPORLendingStrategyMainnet_BTCdc");
+
+const WBTC = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599";
+const WBTC_BALANCES_SLOT = 0;
+const FTOKEN = "0x7659fc26bf3A63E8133BbECB7E16ACD48EE8E292";
+
+describe("Mainnet IPOR Lending BTCdc", function () {
+  let accounts, governance, farmer1, farmer2, reference;
+  let underlying, fToken, fTokenErc20;
+  let controller, vault, strategy;
+
+  // Write straight into WBTC's balances mapping - no whale needed.
+  async function fund(who, amount) {
+    const key = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(["address", "uint256"], [who, WBTC_BALANCES_SLOT]));
+    await network.provider.send("hardhat_setStorageAt", [WBTC, key, ethers.utils.hexZeroPad(ethers.BigNumber.from(amount).toHexString(), 32)]);
+  }
+
+  // Ratios are done in plain numbers: Utils.js configures bignumber.js with DECIMAL_PLACES 0,
+  // so a fractional BigNumber division rounds to an integer. Every value here is < 2^53.
+  const num = (x) => Number(new BigNumber(x).toFixed());
+
+  // The PlasmaVault's own exit fee, measured: previewRedeem is net of it, convertToAssets is not.
+  async function iporExitFee() {
+    const probe = "1000000000000";
+    const gross = num(await fToken.convertToAssets(probe));
+    const net = num(await fToken.previewRedeem(probe));
+    return (gross - net) / gross;
+  }
+
+  // Share price at full precision; getPricePerFullShare() is truncated to the underlying's decimals.
+  async function pricePerShare() {
+    return num(await vault.underlyingBalanceWithInvestment()) / num(await vault.totalSupply());
+  }
+
+  before(async function () {
+    governance = addresses.Governance;
+    accounts = await web3.eth.getAccounts();
+    farmer1 = accounts[1];
+    farmer2 = accounts[2];
+    reference = accounts[3];
+
+    await impersonates([governance]);
+    await web3.eth.sendTransaction({ from: accounts[9], to: governance, value: 10e18 });
+
+    underlying = await IERC20.at(WBTC);
+    fToken = await IERC4626.at(FTOKEN);
+    fTokenErc20 = await IERC20.at(FTOKEN);
+    console.log("Fetching Underlying at: ", underlying.address);
+
+    const vaultImpl = await HookVaultV2.new({ from: governance });
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "vaultImplementationOverride": vaultImpl.address,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+    vault = await HookVaultV2.at(vault.address);
+
+    await fund(farmer1, "90000000");   // 0.9 WBTC
+    await fund(farmer2, "10000000");   // 0.1 WBTC
+    await fund(reference, "90000000");
+  });
+
+  describe("Happy path", function () {
+    it("Farmer gets what a direct PlasmaVault depositor gets, minus only Harvest's fee on profit", async function () {
+      const principal = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, principal.toFixed());
+
+      // The reference enters the PlasmaVault in the same block the strategy does (the
+      // first hard work is what deploys the deposit).
+      await underlying.approve(FTOKEN, principal.toFixed(), { from: reference });
+      await fToken.deposit(principal.toFixed(), reference, { from: reference });
+
+      let hours = 10;
+      let blocksPerHour = 2400;
+      let oldSharePrice;
+      let newSharePrice;
+
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+
+      // The PlasmaVault keeps a redeemer's exit fee, so whoever redeems second collects a
+      // slice of the first one's fee. Measure the two exits from the same state.
+      const snapshot = await network.provider.send("evm_snapshot");
+      await fToken.redeem(new BigNumber(await fTokenErc20.balanceOf(reference)).toFixed(), reference, reference, { from: reference });
+      const referenceGot = new BigNumber(await underlying.balanceOf(reference));
+      await network.provider.send("evm_revert", [snapshot]);
+
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      const farmerGot = new BigNumber(await underlying.balanceOf(farmer1));
+
+      const gain = BigNumber.max(referenceGot.minus(principal), 0);
+      const harvestFee = gain
+        .times(await strategy.totalFeeNumerator())
+        .idiv(await strategy.feeDenominator())
+        .plus(1);
+
+      console.log("principal      ", principal.toFixed());
+      console.log("via Harvest    ", farmerGot.toFixed());
+      console.log("direct to IPOR ", referenceGot.toFixed(), "(Harvest fee on the profit:", harvestFee.toFixed() + ")");
+      console.log("difference     ", farmerGot.minus(referenceGot).toFixed());
+
+      // Rounding: a couple of units across two share conversions and the exit fee.
+      const rounding = referenceGot.idiv(1000000).plus(1);
+      Utils.assertBNGte(farmerGot, referenceGot.minus(harvestFee).minus(rounding));
+      // And the wrapper never gives away more than IPOR does.
+      Utils.assertBNGte(referenceGot.plus(rounding), farmerGot);
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+
+  describe("Exit fee attribution", function () {
+    it("charges the PlasmaVault's exit fee to the withdrawing user only", async function () {
+      await depositVault(farmer1, underlying, vault, new BigNumber(await underlying.balanceOf(farmer1)).toFixed());
+      await depositVault(farmer2, underlying, vault, new BigNumber(await underlying.balanceOf(farmer2)).toFixed());
+      await controller.doHardWork(vault.address, { from: governance });
+      await network.provider.send("evm_mine"); // clear the redemption lock the deposit armed
+
+      const fee = await iporExitFee();
+      const probe = "1000000000000";
+      const iporPps0 = num(await fToken.convertToAssets(probe));
+      const pps0 = await pricePerShare();
+      const entitlement = num(await vault.underlyingBalanceWithInvestmentForHolder(farmer2));
+      const shares = new BigNumber(await vault.balanceOf(farmer2)).toFixed();
+      console.log("  IPOR exit fee      ", (fee * 100).toFixed(4) + "%");
+      console.log("  farmer2 entitlement", entitlement);
+
+      const before = num(await underlying.balanceOf(farmer2));
+      await vault.withdraw(shares, { from: farmer2 });
+      const got = num(await underlying.balanceOf(farmer2)) - before;
+
+      const pps1 = await pricePerShare();
+      const iporPps1 = num(await fToken.convertToAssets(probe));
+      const ipor = iporPps1 / iporPps0;
+      const bystander = pps1 / pps0;
+      // The PlasmaVault refreshes its market balances on a redemption. Whatever that does
+      // to its own share price legitimately reaches every Harvest holder (net of Harvest's
+      // fee on a gain); the exit fee must not.
+      const totalFee = num(await strategy.totalFeeNumerator()) / num(await strategy.feeDenominator());
+      const expected = ipor > 1 ? 1 + (ipor - 1) * (1 - totalFee) : ipor;
+
+      console.log("  farmer2 received   ", got, "=", (got / entitlement * 100).toFixed(4) + "% of entitlement");
+      console.log("  IPOR pps ratio     ", ipor.toFixed(8));
+      console.log("  bystander pps ratio", bystander.toFixed(8), "(expected >=", expected.toFixed(8) + ")");
+
+      // Socialising the fee would cost the bystanders fee x farmer2's share of supply
+      // (~0.01% here); the tolerance is an order of magnitude below that.
+      assert.isTrue(bystander >= expected * (1 - 2e-5), "the exit fee leaked onto the remaining holders");
+      // The withdrawer paid the fee, and nothing beyond the fee and IPOR's own revaluation.
+      assert.isTrue(got <= entitlement * (1 - fee) * (1 + 1e-4), "the withdrawer did not pay the exit fee");
+      assert.isTrue(got >= entitlement * (1 - fee) * ipor * (1 - 1e-4), "the withdrawer was charged more than the exit fee");
+    });
+  });
+});

--- a/test/erc4626/ipor-hook.js
+++ b/test/erc4626/ipor-hook.js
@@ -1,0 +1,187 @@
+// compoundOnWithdraw on an IPOR PlasmaVault, through HookVaultV2 + IHardWorkHooks.
+//
+// IPOR locks the depositing account against redemption until block.timestamp + 1, i.e.
+// for the rest of the block. A plain doHardWork() ends by depositing into the PlasmaVault,
+// so running it inside a withdrawal that then redeems from the same PlasmaVault reverts
+// with AccountIsLocked(uint256). The strategy's doHardWorkOnWithdraw() credits the exiting
+// user the same accrued interest without the deposit, and HookVaultV2 uses it.
+//
+// Developed and tested at blockNumber 25933440
+
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const BigNumber = require("bignumber.js");
+const { ethers, network } = require("hardhat");
+
+const IERC20 = artifacts.require("IERC20");
+const IERC4626 = artifacts.require("contracts/base/interface/IERC4626.sol:IERC4626");
+const HookVaultV2 = artifacts.require("HookVaultV2");
+const Strategy = artifacts.require("IPORLendingStrategyMainnet_bdUSD");
+
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const USDC_BALANCES_SLOT = 9;
+const FTOKEN = "0xF8F226dA66244F89e70C5B5D1a5C5b0d505Eb1d8";
+const LOCKED = "a592703b"; // AccountIsLocked(uint256)
+
+describe("Mainnet IPOR Lending bdUSD - compoundOnWithdraw", function () {
+  let accounts, governance, farmer1, farmer2, donor;
+  let underlying, fToken;
+  let controller, vault, strategy;
+
+  async function fund(who, amount) {
+    const key = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(["address", "uint256"], [who, USDC_BALANCES_SLOT]));
+    await network.provider.send("hardhat_setStorageAt", [USDC, key, ethers.utils.hexZeroPad(ethers.BigNumber.from(amount).toHexString(), 32)]);
+  }
+
+  // Grows the strategy's PlasmaVault position without touching storedBalance - what
+  // accrued-but-unharvested interest looks like. The PlasmaVault caches its market
+  // balances, so advancing time does not move convertToAssets on a fork; depositing on the
+  // strategy's behalf produces the same stale-storedBalance state deterministically.
+  async function accrueInterest(amount) {
+    await underlying.approve(FTOKEN, amount, { from: donor });
+    await fToken.deposit(amount, strategy.address, { from: donor });
+    await network.provider.send("evm_mine"); // clear the lock the donation armed
+  }
+
+  async function revertDataOf(txHash) {
+    const tr = await network.provider.send("debug_traceTransaction", [txHash]);
+    return (tr.returnValue || "").replace(/^0x/, "");
+  }
+
+  before(async function () {
+    governance = addresses.Governance;
+    accounts = await web3.eth.getAccounts();
+    farmer1 = accounts[1];
+    farmer2 = accounts[2];
+    donor = accounts[3];
+
+    await impersonates([governance]);
+    await web3.eth.sendTransaction({ from: accounts[9], to: governance, value: 10e18 });
+
+    underlying = await IERC20.at(USDC);
+    fToken = await IERC4626.at(FTOKEN);
+
+    const vaultImpl = await HookVaultV2.new({ from: governance });
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "vaultImplementationOverride": vaultImpl.address,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+    vault = await HookVaultV2.at(vault.address);
+
+    await fund(farmer1, "90000000000"); // 90,000 USDC
+    await fund(farmer2, "10000000000"); // 10,000 USDC
+    await fund(donor, "10000000000");
+
+    await depositVault(farmer1, underlying, vault, "90000000000");
+    await depositVault(farmer2, underlying, vault, "10000000000");
+    await controller.doHardWork(vault.address, { from: governance });
+    await network.provider.send("evm_mine");
+  });
+
+  it("is off by default, and only governance can turn it on", async function () {
+    assert.isFalse(await vault.compoundOnWithdraw());
+    let msg = "";
+    try { await vault.setCompoundOnWithdraw(true, { from: farmer1 }); } catch (e) { msg = e.message || ""; }
+    assert.include(msg, "Not governance");
+    assert.isTrue(await strategy.supportsHardWorkHooks());
+  });
+
+  it("control: a hard work and a redemption in the same block hit the redemption lock", async function () {
+    // Idle underlying in the vault, so the hard work has something to deposit.
+    await fund(farmer1, "1000000000");
+    await depositVault(farmer1, underlying, vault, "1000000000");
+
+    const shares = (await vault.balanceOf(farmer2)).toString();
+    const ctrl = await ethers.getContractAt(["function doHardWork(address)"], controller.address, await ethers.getSigner(governance));
+    const v = await ethers.getContractAt(["function withdraw(uint256) returns (uint256)"], vault.address, await ethers.getSigner(farmer2));
+
+    await network.provider.send("evm_setAutomine", [false]);
+    const hardWork = await ctrl.doHardWork(vault.address, { gasLimit: 6000000 });
+    const withdrawal = await v["withdraw(uint256)"](shares, { gasLimit: 6000000 });
+    await network.provider.send("evm_mine");
+    await network.provider.send("evm_setAutomine", [true]);
+
+    const r1 = await ethers.provider.getTransactionReceipt(hardWork.hash);
+    const r2 = await ethers.provider.getTransactionReceipt(withdrawal.hash);
+    assert.equal(r1.blockNumber, r2.blockNumber, "both must land in one block");
+    assert.equal(r1.status, 1, "the hard work itself must succeed");
+    assert.equal(r2.status, 0, "precondition: the same-block redemption must be refused");
+    const data = await revertDataOf(withdrawal.hash);
+    console.log("  same-block withdrawal reverted with", "0x" + data.slice(0, 8));
+    assert.include(data, LOCKED, "should revert with AccountIsLocked");
+    assert.equal((await vault.balanceOf(farmer2)).toString(), shares, "the failed withdrawal must not have burned anything");
+    await network.provider.send("evm_mine");
+  });
+
+  it("credits the withdrawing user the interest accrued since the last hard work", async function () {
+    await accrueInterest("5000000000"); // +5,000 USDC on the strategy's position
+
+    const stored = new BigNumber(await strategy.storedBalance());
+    const current = new BigNumber(await strategy.currentBalance());
+    console.log("  stored ", stored.toFixed());
+    console.log("  current", current.toFixed(), "(gap", current.minus(stored).toFixed() + ")");
+    assert.isTrue(current.gt(stored), "precondition: interest must have accrued");
+
+    // Price farmer2's partial exit with the flag off vs on, from the same state.
+    const shares = (await vault.balanceOf(farmer2)).toString();
+    const snapshot = await network.provider.send("evm_snapshot");
+    const b0 = new BigNumber(await underlying.balanceOf(farmer2));
+    await vault.withdraw(shares, { from: farmer2 });
+    const withoutCompound = new BigNumber(await underlying.balanceOf(farmer2)).minus(b0);
+    await network.provider.send("evm_revert", [snapshot]);
+
+    await vault.setCompoundOnWithdraw(true, { from: governance });
+    const b1 = new BigNumber(await underlying.balanceOf(farmer2));
+    await vault.withdraw(shares, { from: farmer2 });
+    const withCompound = new BigNumber(await underlying.balanceOf(farmer2)).minus(b1);
+
+    console.log("  received without compoundOnWithdraw:", withoutCompound.toFixed());
+    console.log("  received with    compoundOnWithdraw:", withCompound.toFixed());
+    Utils.assertBNGt(withCompound, withoutCompound);
+    assert.equal((await vault.balanceOf(farmer2)).toString(), "0");
+  });
+
+  it("does not deposit into the PlasmaVault on the withdrawal path", async function () {
+    assert.isTrue(await vault.compoundOnWithdraw());
+    // Everything invested, then idle underlying in the strategy: a full doHardWork() would
+    // deposit it, arm the lock, and the redemption a few lines later would revert (the
+    // control above). The hook leaves it idle, and the redemption goes through.
+    await fund(farmer2, "10000000000");
+    await depositVault(farmer2, underlying, vault, "10000000000");
+    await controller.doHardWork(vault.address, { from: governance });
+    await underlying.transfer(strategy.address, "1000000000", { from: donor });
+    await network.provider.send("evm_mine");
+    assert.equal((await vault.underlyingBalanceInVault()).toString(), "0", "precondition: the exit must redeem from the PlasmaVault");
+
+    const positionBefore = new BigNumber(await strategy.currentBalance());
+    const shares = (await vault.balanceOf(farmer2)).toString();
+    await vault.withdraw(shares, { from: farmer2 });
+    const positionAfter = new BigNumber(await strategy.currentBalance());
+
+    console.log("  PlasmaVault position", positionBefore.toFixed(), "->", positionAfter.toFixed());
+    Utils.assertBNGt(positionBefore, positionAfter);
+    assert.equal((await vault.balanceOf(farmer2)).toString(), "0");
+  });
+
+  it("keeps doHardWork() deploying capital, so the keeper is unaffected", async function () {
+    await underlying.transfer(strategy.address, "1000000000", { from: donor });
+    const idleBefore = new BigNumber(await underlying.balanceOf(strategy.address));
+    const suppliedBefore = new BigNumber(await strategy.currentBalance());
+    assert.isTrue(idleBefore.gt(0));
+
+    await controller.doHardWork(vault.address, { from: governance });
+
+    const idleAfter = new BigNumber(await underlying.balanceOf(strategy.address));
+    const suppliedAfter = new BigNumber(await strategy.currentBalance());
+    console.log("  idle    ", idleBefore.toFixed(), "->", idleAfter.toFixed());
+    console.log("  supplied", suppliedBefore.toFixed(), "->", suppliedAfter.toFixed());
+    Utils.assertBNGt(suppliedAfter, suppliedBefore);
+    assert.isTrue(idleAfter.lt(idleBefore), "keeper harvest should deploy the idle balance");
+  });
+});

--- a/test/vault/hook-vault-deposit-cap.js
+++ b/test/vault/hook-vault-deposit-cap.js
@@ -1,0 +1,118 @@
+// The governance deposit cap on HookVaultV2. Off by default (cap 0 = uncapped), enforced
+// before any funds move, and reflected in the ERC-4626 maxDeposit/maxMint views so an
+// integrator sizing a deposit is told the real limit instead of type(uint256).max.
+//
+// Exercised against a live USDC vault so the cap is measured against real TVL.
+//
+// Developed and tested at blockNumber 25933440
+
+const Utils = require("../utilities/Utils.js");
+const { impersonates } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const BigNumber = require("bignumber.js");
+const { ethers, network } = require("hardhat");
+
+const IERC20 = artifacts.require("IERC20");
+const VaultV2 = artifacts.require("VaultV2");
+const HookVaultV2 = artifacts.require("HookVaultV2");
+const VaultProxy = artifacts.require("VaultProxy");
+
+const VAULT = "0xf0358e8c3CD5Fa238a29301d0bEa3D63A17bEdBE"; // fUSDC
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const USDC_BALANCES_SLOT = 9;
+const MAX_UINT = new BigNumber(2).pow(256).minus(1);
+
+describe("HookVaultV2 deposit cap", function () {
+  let governance, farmer, usdc, vault;
+
+  async function fund(who, amount) {
+    const key = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(["address", "uint256"], [who, USDC_BALANCES_SLOT]));
+    await network.provider.send("hardhat_setStorageAt", [USDC, key, ethers.utils.hexZeroPad(ethers.BigNumber.from(amount).toHexString(), 32)]);
+  }
+
+  async function revertsWith(fn, fragment) {
+    let msg = "";
+    try { await fn(); } catch (e) { msg = e.message || ""; }
+    assert.include(msg, fragment, `expected a revert containing "${fragment}"`);
+    return msg;
+  }
+
+  before(async function () {
+    governance = addresses.Governance;
+    const accounts = await web3.eth.getAccounts();
+    farmer = accounts[1];
+
+    await impersonates([governance]);
+    await web3.eth.sendTransaction({ from: accounts[9], to: governance, value: 10e18 });
+
+    usdc = await IERC20.at(USDC);
+    await fund(farmer, "30000000000");
+    await usdc.approve(VAULT, "30000000000", { from: farmer });
+
+    const stock = await VaultV2.at(VAULT);
+    const impl = await HookVaultV2.new({ from: governance });
+    await stock.scheduleUpgrade(impl.address, { from: governance });
+    await Utils.waitHours(13);
+    await (await VaultProxy.at(VAULT)).upgrade({ from: governance });
+    vault = await HookVaultV2.at(VAULT);
+  });
+
+  it("defaults to uncapped, and the ERC-4626 views say so", async function () {
+    assert.equal((await vault.depositCap()).toString(), "0", "cap must default to 0");
+    assert.equal((await vault.maxDeposit(farmer)).toString(), MAX_UINT.toFixed());
+    assert.equal((await vault.maxMint(farmer)).toString(), MAX_UINT.toFixed());
+  });
+
+  it("only governance can set the cap", async function () {
+    await revertsWith(() => vault.setDepositCap("1", { from: farmer }), "Not governance");
+    assert.equal((await vault.depositCap()).toString(), "0", "cap must be unchanged");
+  });
+
+  it("accepts deposits up to the cap and rejects the one that would cross it", async function () {
+    const tvl = new BigNumber(await vault.underlyingBalanceWithInvestment());
+    const cap = tvl.plus("1000000000"); // 1,000 USDC of headroom
+    await vault.setDepositCap(cap.toFixed(), { from: governance });
+    console.log("  TVL", tvl.toFixed(), "cap", cap.toFixed());
+
+    const room = new BigNumber(await vault.maxDeposit(farmer));
+    console.log("  maxDeposit reports", room.toFixed());
+    assert.isTrue(room.lte("1000000000") && room.gt("990000000"), "maxDeposit should report the real headroom");
+
+    // maxMint must agree with maxDeposit.
+    const mintable = new BigNumber(await vault.maxMint(farmer));
+    const expected = new BigNumber(await vault.convertToShares(room.toFixed()));
+    assert.equal(mintable.toFixed(), expected.toFixed(), "maxMint must equal convertToShares(maxDeposit)");
+
+    await vault.methods["deposit(uint256)"]("900000000", { from: farmer }); // inside the cap
+    await revertsWith(
+      () => vault.methods["deposit(uint256)"]("500000000", { from: farmer }), // would cross it
+      "Deposit cap reached"
+    );
+    console.log("  over-cap deposit correctly rejected");
+  });
+
+  it("blocks deposits but never traps funds when the cap is below TVL", async function () {
+    await vault.setDepositCap("1", { from: governance });
+    assert.equal((await vault.maxDeposit(farmer)).toString(), "0", "no headroom left");
+    assert.equal((await vault.maxMint(farmer)).toString(), "0");
+    await revertsWith(() => vault.methods["deposit(uint256)"]("1000000", { from: farmer }), "Deposit cap reached");
+
+    // Existing holders must still be able to leave.
+    const shares = (await vault.balanceOf(farmer)).toString();
+    const before = new BigNumber(await usdc.balanceOf(farmer));
+    await vault.methods["withdraw(uint256)"](shares, { from: farmer });
+    const after = new BigNumber(await usdc.balanceOf(farmer));
+    console.log("  withdrawal under a binding cap returned", after.minus(before).toFixed());
+    Utils.assertBNGt(after, before);
+  });
+
+  it("clearing the cap restores uncapped behaviour", async function () {
+    await vault.setDepositCap(0, { from: governance });
+    assert.equal((await vault.depositCap()).toString(), "0");
+    assert.equal((await vault.maxDeposit(farmer)).toString(), MAX_UINT.toFixed());
+    await vault.methods["deposit(uint256)"]("5000000000", { from: farmer });
+    Utils.assertBNGt(new BigNumber(await vault.balanceOf(farmer)), new BigNumber(0));
+    console.log("  large deposit accepted after clearing the cap");
+  });
+});

--- a/test/vault/hook-vault-fallback.js
+++ b/test/vault/hook-vault-fallback.js
@@ -81,6 +81,20 @@ describe("HookVaultV2 as a drop-in for VaultV2", function () {
   });
 
   it("with everything off, produces the same result as stock VaultV2", async function () {
+    // This file and hook-vault-deposit-cap.js target the same live proxy, and that one
+    // upgrades it permanently. Run in one process (`npx hardhat test test/vault/`) mocha
+    // loads them alphabetically, so without this check the comparison below would be
+    // HookVaultV2 against HookVaultV2 and could no longer detect any divergence.
+    const implSlot = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+    const currentImpl = ethers.utils.getAddress(
+      "0x" + (await network.provider.send("eth_getStorageAt", [VAULT, implSlot, "latest"])).slice(-40)
+    );
+    assert.equal(
+      currentImpl.toLowerCase(), addresses.VaultImplementationV2.toLowerCase(),
+      "this comparison is only meaningful against the stock implementation - " +
+      "run this file on its own, not in the same process as hook-vault-deposit-cap.js"
+    );
+
     // The upgrade path burns 13 hours on the timelock, and the underlying protocol
     // accrues in that time. Give both runs the same elapsed time and the same transaction
     // count so the only difference measured is the vault implementation.

--- a/test/vault/hook-vault-fallback.js
+++ b/test/vault/hook-vault-fallback.js
@@ -1,0 +1,145 @@
+// HookVaultV2 must be a drop-in replacement for VaultV2. With both of its settings off
+// (the default) it behaves identically to the stock implementation; and when the strategy
+// does NOT implement IHardWorkHooks, compoundOnWithdraw falls back to IStrategy.doHardWork().
+//
+// Exercised against a live USDC vault whose strategy has no hooks.
+//
+// Developed and tested at blockNumber 25933440
+
+const Utils = require("../utilities/Utils.js");
+const { impersonates } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const BigNumber = require("bignumber.js");
+const { ethers, network } = require("hardhat");
+
+const IERC20 = artifacts.require("IERC20");
+const VaultV2 = artifacts.require("VaultV2");
+const HookVaultV2 = artifacts.require("HookVaultV2");
+const VaultProxy = artifacts.require("VaultProxy");
+const IController = artifacts.require("IController");
+
+const VAULT = "0xf0358e8c3CD5Fa238a29301d0bEa3D63A17bEdBE"; // fUSDC
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const USDC_BALANCES_SLOT = 9;
+
+describe("HookVaultV2 as a drop-in for VaultV2", function () {
+  let accounts, governance, farmer;
+  let usdc, stockVault, hookVault, strategy, controller;
+
+  async function fund(who, amount) {
+    const key = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(["address", "uint256"], [who, USDC_BALANCES_SLOT]));
+    await network.provider.send("hardhat_setStorageAt", [USDC, key, ethers.utils.hexZeroPad(ethers.BigNumber.from(amount).toHexString(), 32)]);
+  }
+
+  async function depositAndWithdraw(vaultInstance, label) {
+    const amount = "1000000000"; // 1,000 USDC
+    const before = new BigNumber(await usdc.balanceOf(farmer));
+    await vaultInstance.methods["deposit(uint256)"](amount, { from: farmer });
+    const shares = (await vaultInstance.balanceOf(farmer)).toString();
+    await vaultInstance.methods["withdraw(uint256)"](shares, { from: farmer });
+    const after = new BigNumber(await usdc.balanceOf(farmer));
+    const delta = after.minus(before);
+    console.log(`  ${label}: shares minted ${shares}, USDC delta ${delta.toFixed()}`);
+    return { shares, delta };
+  }
+
+  before(async function () {
+    governance = addresses.Governance;
+    accounts = await web3.eth.getAccounts();
+    farmer = accounts[1];
+
+    await impersonates([governance]);
+    await web3.eth.sendTransaction({ from: accounts[9], to: governance, value: 10e18 });
+
+    usdc = await IERC20.at(USDC);
+    stockVault = await VaultV2.at(VAULT);
+    controller = await IController.at(await stockVault.controller());
+    strategy = await stockVault.strategy();
+
+    await fund(farmer, "10000000000");
+    await usdc.approve(VAULT, "10000000000", { from: farmer });
+    console.log("Vault:", VAULT, "strategy:", strategy);
+  });
+
+  it("the strategy genuinely has no hooks", async function () {
+    // Mirror HookVaultV2._supportsHardWorkHooks exactly: a proxy without the function
+    // may return empty data instead of reverting, which must read as "not supported".
+    let supported = false;
+    try {
+      const data = await ethers.provider.call({
+        to: strategy,
+        data: ethers.utils.id("supportsHardWorkHooks()").slice(0, 10),
+      });
+      supported = ethers.utils.hexDataLength(data) === 32 &&
+        ethers.utils.defaultAbiCoder.decode(["bool"], data)[0];
+    } catch (e) {
+      supported = false;
+    }
+    console.log("  strategy advertises hooks:", supported);
+    assert.isFalse(supported, "this test needs a strategy WITHOUT the hooks");
+  });
+
+  it("with everything off, produces the same result as stock VaultV2", async function () {
+    // The upgrade path burns 13 hours on the timelock, and the underlying protocol
+    // accrues in that time. Give both runs the same elapsed time and the same transaction
+    // count so the only difference measured is the vault implementation.
+    const impl = await HookVaultV2.new({ from: governance });
+    await stockVault.scheduleUpgrade(impl.address, { from: governance });
+
+    const snapshot = await network.provider.send("evm_snapshot");
+    await Utils.waitHours(13);
+    await network.provider.send("evm_mine"); // stands in for the upgrade() transaction
+    const stock = await depositAndWithdraw(stockVault, "stock VaultV2   ");
+    await network.provider.send("evm_revert", [snapshot]);
+
+    await Utils.waitHours(13);
+    await (await VaultProxy.at(VAULT)).upgrade({ from: governance });
+    hookVault = await HookVaultV2.at(VAULT);
+    assert.isFalse(await hookVault.compoundOnWithdraw());
+    assert.equal((await hookVault.depositCap()).toString(), "0");
+    const hooked = await depositAndWithdraw(hookVault, "HookVaultV2     ");
+
+    assert.equal(hooked.shares, stock.shares, "share mint must be identical");
+    assert.equal(hooked.delta.toFixed(), stock.delta.toFixed(), "USDC returned must be identical");
+  });
+
+  it("with compoundOnWithdraw on, falls back to doHardWork() inside the withdrawal", async function () {
+    // Idle underlying parked in the strategy is only deployed by a hard work, so whether
+    // it is still there after the withdrawal shows whether one ran inside it. The
+    // round-trip deposit is served from the vault's own balance either way, so nothing
+    // else touches the strategy.
+    const idle = "500000000"; // 500 USDC
+    const donor = accounts[2];
+    async function parkIdle() {
+      await fund(donor, idle);
+      await usdc.transfer(strategy, idle, { from: donor });
+    }
+
+    const snapshot = await network.provider.send("evm_snapshot");
+    await parkIdle();
+    const off = await depositAndWithdraw(hookVault, "compoundOnWithdraw off");
+    const idleOff = new BigNumber(await usdc.balanceOf(strategy));
+    await network.provider.send("evm_revert", [snapshot]);
+
+    await hookVault.setCompoundOnWithdraw(true, { from: governance });
+    await parkIdle();
+    const on = await depositAndWithdraw(hookVault, "compoundOnWithdraw on ");
+    const idleOn = new BigNumber(await usdc.balanceOf(strategy));
+    console.log("  idle left in the strategy: off", idleOff.toFixed(), "/ on", idleOn.toFixed());
+
+    assert.equal(on.shares, off.shares, "the deposit path is untouched by the flag");
+    Utils.assertBNGte(on.delta, off.delta);
+    assert.equal(idleOff.toFixed(), idle, "no hard work must run with the flag off");
+    assert.isTrue(idleOn.lt(new BigNumber(idle).idiv(100)), "the fallback doHardWork() must have deployed the idle balance");
+  });
+
+  it("still lets the keeper harvest through HookVaultV2", async function () {
+    const ppsBefore = new BigNumber(await hookVault.getPricePerFullShare());
+    await Utils.advanceNBlock(100);
+    await controller.doHardWork(VAULT, { from: governance });
+    const ppsAfter = new BigNumber(await hookVault.getPricePerFullShare());
+    console.log("  pps", ppsBefore.toFixed(), "->", ppsAfter.toFixed());
+    assert.isTrue(ppsAfter.gte(ppsBefore), "share price must not fall across a harvest");
+  });
+});

--- a/test/vault/hook-vault-upstream-drift.js
+++ b/test/vault/hook-vault-upstream-drift.js
@@ -1,0 +1,211 @@
+"use strict";
+/**
+ * Upstream-drift guard for HookVaultV2.
+ *
+ * HookVaultV2._withdraw is a verbatim copy of VaultV1._withdraw with exactly two edits.
+ * Solidity cannot enforce that: patching the *body* of VaultV1._withdraw recompiles
+ * cleanly and leaves HookVaultV2's runtime bytecode byte-identical, i.e. the upstream
+ * change is silently dropped for every vault running the Hook implementation. Only a
+ * signature change, or removal of `virtual`, fails loudly at compile time.
+ *
+ * This guard closes the silent gap. Pure source analysis: no fork, no compile, ~10ms.
+ *   npx mocha test/vault/hook-vault-upstream-drift.js
+ */
+const fs = require("fs");
+const path = require("path");
+const assert = require("assert");
+const { execFileSync } = require("child_process");
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const VAULT_V1 = path.join(ROOT, "contracts", "base", "VaultV1.sol");
+const HOOK = path.join(ROOT, "contracts", "base", "HookVaultV2.sol");
+const read = (p) => fs.readFileSync(p, "utf8");
+
+// The complete, exhaustive list of intentional differences between the two bodies.
+const INTENTIONAL_EDITS = [
+  {
+    name: "signature: virtual -> virtual override",
+    from: "function _withdraw(uint256 numberOfShares, address receiver, address owner) internal virtual returns (uint256) {",
+    to: "function _withdraw(uint256 numberOfShares, address receiver, address owner) internal virtual override returns (uint256) {",
+  },
+  {
+    name: "hard work hook inserted after the burn",
+    from: "_burn(owner, numberOfShares);",
+    to: "_burn(owner, numberOfShares);\n\n    if (compoundOnWithdraw()) {\n      _hardWorkOnWithdraw();\n    }",
+  },
+];
+
+// The base vaults are kept at upstream parity except for these `virtual` keywords,
+// which let HookVaultV2 override.
+const ALLOWED_BASE_DIVERGENCE = new Set([
+  "-  function _deposit(uint256 amount, address sender, address beneficiary) internal returns (uint256) {",
+  "+  function _deposit(uint256 amount, address sender, address beneficiary) internal virtual returns (uint256) {",
+  "-  function _withdraw(uint256 numberOfShares, address receiver, address owner) internal returns (uint256) {",
+  "+  function _withdraw(uint256 numberOfShares, address receiver, address owner) internal virtual returns (uint256) {",
+  // VaultV2: opened up so a flavour can report remaining capacity under a deposit cap.
+  "-    function maxDeposit(address /*caller*/) public view override returns (uint256) {",
+  "+    function maxDeposit(address /*caller*/) public view virtual override returns (uint256) {",
+  "-    function maxMint(address /*caller*/) public view override returns (uint256) {",
+  "+    function maxMint(address /*caller*/) public view virtual override returns (uint256) {",
+]);
+
+function extractFunction(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start < 0) return null;
+  const open = src.indexOf("{", start);
+  if (open < 0) return null;
+  let depth = 0;
+  for (let k = open; k < src.length; k++) {
+    if (src[k] === "{") depth++;
+    else if (src[k] === "}" && --depth === 0) return src.slice(start, k + 1);
+  }
+  return null;
+}
+
+// Strip comments / blank lines / indentation so formatting churn is not treated as drift.
+const normalise = (body) =>
+  body
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .map((l) => l.replace(/\/\/.*$/, "").trim())
+    .filter(Boolean);
+
+function checkParity(vaultV1Src, hookSrc) {
+  const base = extractFunction(vaultV1Src, "_withdraw");
+  const hook = extractFunction(hookSrc, "_withdraw");
+  if (!base) return { ok: false, reason: "VaultV1._withdraw not found - the base vault was restructured" };
+  if (!hook) return { ok: false, reason: "HookVaultV2._withdraw not found - the override was removed or renamed" };
+
+  // Rebuild what the override *should* be from the current upstream body.
+  let expected = base;
+  const anchorProblems = [];
+  for (const e of INTENTIONAL_EDITS) {
+    const n = expected.split(e.from).length - 1;
+    if (n === 0) anchorProblems.push(`${e.name}: anchor gone from VaultV1._withdraw -> "${e.from.trim()}"`);
+    else if (n > 1) anchorProblems.push(`${e.name}: anchor now occurs ${n}x - ambiguous, re-anchor this edit`);
+    else expected = expected.replace(e.from, e.to);
+  }
+  if (anchorProblems.length) return { ok: false, reason: "an intentional-edit anchor moved", detail: anchorProblems };
+
+  const a = normalise(expected);
+  const b = normalise(hook);
+  if (a.length === b.length && a.every((l, i) => l === b[i])) return { ok: true };
+
+  const detail = [];
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    if (a[i] !== b[i]) {
+      detail.push(`line ${i + 1}:`);
+      detail.push(`  expected (VaultV1 + intentional edits): ${a[i] ?? "<absent>"}`);
+      detail.push(`  actual   (HookVaultV2)                : ${b[i] ?? "<absent>"}`);
+    }
+  }
+  return { ok: false, reason: "HookVaultV2._withdraw has drifted from VaultV1._withdraw", detail };
+}
+
+const explain = (res) =>
+  [
+    "",
+    `  ${res.reason}`,
+    ...(res.detail || []).map((l) => "    " + l),
+    "",
+    "  VaultV1._withdraw changed and Solidity will NOT flag it: HookVaultV2 overrides",
+    "  _withdraw, so it keeps the old body and the change never reaches vaults running",
+    "  the Hook implementation. Re-copy VaultV1._withdraw and re-apply the two edits.",
+  ].join("\n");
+
+describe("HookVaultV2 upstream-drift guard", function () {
+  it("HookVaultV2._withdraw is VaultV1._withdraw plus exactly the two intentional edits", function () {
+    const res = checkParity(read(VAULT_V1), read(HOOK));
+    assert.ok(res.ok, explain(res));
+  });
+
+  it("HookVaultV2 overrides only the withdraw hook and the deposit-cap surface", function () {
+    const src = read(HOOK);
+    const overrides = (src.match(/function\s+(\w+)\s*\([^)]*\)[^{;]*\boverride\b/g) || []).map(
+      (m) => m.match(/function\s+(\w+)/)[1]
+    );
+    assert.deepStrictEqual(
+      overrides.sort(),
+      ["_deposit", "_withdraw", "maxDeposit", "maxMint"],
+      "HookVaultV2 must override only the withdraw hook and the deposit-cap surface"
+    );
+    // _deposit is a cap check in front of the inherited body, never a copy of it: it must
+    // delegate to super, and must not restate VaultV1's deposit logic.
+    const dep = extractFunction(src, "_deposit");
+    assert.ok(dep, "HookVaultV2 must define _deposit");
+    assert.ok(
+      /return super\._deposit\(amount, sender, beneficiary\);/.test(dep),
+      "HookVaultV2._deposit must delegate to super._deposit"
+    );
+    assert.ok(
+      !/safeTransferFrom|_mint\(/.test(dep),
+      "HookVaultV2._deposit must not duplicate VaultV1._deposit's body"
+    );
+  });
+
+  it("VaultV1/VaultV2/VaultStorage differ from upstream only by the known opened-up signatures", function () {
+    let diff;
+    try {
+      diff = execFileSync(
+        "git",
+        ["diff", "upstream/master", "--",
+         "contracts/base/VaultV1.sol", "contracts/base/VaultV2.sol", "contracts/base/VaultStorage.sol"],
+        { cwd: ROOT, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
+      );
+    } catch (e) {
+      this.skip(); // `git fetch upstream` has not been run here
+      return;
+    }
+    const unexpected = diff
+      .split("\n")
+      .filter((l) => /^[+-]/.test(l) && !/^(\+\+\+|---)/.test(l))
+      .filter((l) => !ALLOWED_BASE_DIVERGENCE.has(l));
+    assert.deepStrictEqual(
+      unexpected, [],
+      "\n  The base vaults drifted from upstream beyond the known opened-up signatures:\n" +
+        unexpected.map((l) => "    " + l).join("\n") +
+        "\n  Fold the change upstream, or move it into a vault flavour."
+    );
+  });
+
+  // A guard that quietly stops guarding is worse than no guard. These synthetic
+  // mutations must all be caught.
+  describe("self-test: the guard must fail on real drift", function () {
+    const v1 = () => read(VAULT_V1);
+    const hook = () => read(HOOK);
+    const mustFail = (label, mutate) =>
+      it(label, () => assert.strictEqual(checkParity(mutate(v1()), hook()).ok, false, "guard failed to catch: " + label));
+
+    mustFail("upstream inserts a clamp line into the body (the silent case)", (s) =>
+      s.replace(
+        "    IERC20Upgradeable(underlying()).safeTransfer(receiver, underlyingAmountToWithdraw);",
+        "    underlyingAmountToWithdraw = MathUpgradeable.min(underlyingAmountToWithdraw, underlyingBalanceInVault());\n" +
+        "    IERC20Upgradeable(underlying()).safeTransfer(receiver, underlyingAmountToWithdraw);"
+      ));
+
+    mustFail("upstream moves _burn after the strategy withdrawal", (s) =>
+      s.replace("    _burn(owner, numberOfShares);\n", "")
+       .replace("    IERC20Upgradeable(underlying()).safeTransfer(receiver, underlyingAmountToWithdraw);",
+                "    _burn(owner, numberOfShares);\n    IERC20Upgradeable(underlying()).safeTransfer(receiver, underlyingAmountToWithdraw);"));
+
+    mustFail("upstream changes the _withdraw signature", (s) =>
+      s.replace(
+        "function _withdraw(uint256 numberOfShares, address receiver, address owner) internal virtual returns (uint256) {",
+        "function _withdraw(uint256 numberOfShares, address receiver, address owner, uint256 minOut) internal virtual returns (uint256) {"
+      ));
+
+    mustFail("upstream changes the pricing math", (s) =>
+      s.replace("    uint256 underlyingAmountToWithdraw = underlyingBalanceWithInvestment()\n        .mul(numberOfShares)\n        .div(totalSupply);",
+                "    uint256 underlyingAmountToWithdraw = underlyingBalanceWithInvestment()\n        .mul(numberOfShares)\n        .div(totalSupply.add(1));"));
+
+    mustFail("the burn anchor becomes ambiguous (appears twice)", (s) =>
+      s.replace("    _burn(owner, numberOfShares);\n", "    _burn(owner, numberOfShares);\n    _burn(owner, numberOfShares);\n"));
+
+    it("tolerates cosmetic reformatting (must NOT false-positive)", function () {
+      const cosmetic = v1().replace("    _burn(owner, numberOfShares);", "    _burn(owner, numberOfShares); // accounting");
+      assert.strictEqual(checkParity(cosmetic, hook()).ok, true, "guard false-positived on a comment-only change");
+    });
+  });
+});
+
+module.exports = { checkParity, extractFunction, normalise, INTENTIONAL_EDITS };


### PR DESCRIPTION
Brings the IPOR Fusion work from `harvest-strategy-base` over to Ethereum and adds strategies for the two fee-charging Fusion vaults.

## Strategies

- **`GeneralERC4626Strategy`** — ported from the Base repo. Redeems by shares rather than `withdraw(assets)`, so an ERC4626 vault's exit fee is charged to the user whose withdrawal triggers the redemption instead of being spread over every holder.
- **`IPORLendingStrategyMainnet_bdUSD`** — USDC into [`0xF8F226dA…`](https://etherscan.io/address/0xF8F226dA66244F89e70C5B5D1a5C5b0d505Eb1d8), 0.20% off-boarding fee.
- **`IPORLendingStrategyMainnet_BTCdc`** — WBTC into [`0x7659fc26…`](https://etherscan.io/address/0x7659fc26bf3A63E8133BbECB7E16ACD48EE8E292), 0.10%.

Both run on the stock `VaultV2` the factory already deploys — the vault work below is not required for them.

## Vault

- `VaultV1._deposit`/`_withdraw` and `VaultV2.maxDeposit`/`maxMint` gain `virtual`. No behaviour or storage change.
- **`IHardWorkHooks`** — optional strategy interface offering a withdrawal-safe hard work.
- **`HookVaultV2`** — `VaultV2` plus two governance settings, **both off by default** and held in dedicated hashed slots, so it is a drop-in implementation for an existing proxy:
  - `compoundOnWithdraw` — runs `doHardWorkOnWithdraw()` when the strategy offers it, `doHardWork()` otherwise, before pricing a withdrawal. IPOR locks a depositing account against redemption for the rest of the block, so a plain `doHardWork()` inside a withdrawal reverts with `AccountIsLocked`; the hook credits the same accrued interest without depositing.
  - `depositCap` — enforced before funds move and reported through `maxDeposit`/`maxMint`.

  A refused hard work never blocks an exit: it degrades to stock pricing and emits `HardWorkOnWithdrawSkipped`. Twenty strategy families here revert `doHardWork()` once `pausedInvesting` is set, so without that an `emergencyExit()` would have frozen every withdrawal from such a vault.

## Fee handling in `GeneralERC4626Strategy`

- Brought in line with the fleet fix in a494be9: `withdrawAllToVault` keeps an unpayable `pendingFee` back and `investedUnderlyingBalance()` clamps at zero, with the dust floor behind a `feeFloor()` virtual. Without it a `pendingFee` under the floor made `investedUnderlyingBalance()` underflow — the sole holder's full exit reverted, and a governance `withdrawAll()` left the share price, deposits and withdrawals all reverting. On 8-decimal WBTC the floor is only ~6,700 sat (~$7) of gain between harvests, so BTCdc reaches it in ordinary use.
- **High water mark on the performance fee**, scoped to this strategy only. A fall in value is remembered in `lossCarry` and offsets later gains, so depositors are no longer charged for earning a loss back. Measured on the fork with a 90,000 USDC position: a 4,576 USDC dip and recovery used to cost ~686 USDC for a net-zero move; depositors now keep 100% of a recovery and 85% of a genuine new high at a 15% fee.

## Exit-fee policy

The position is marked **gross** (`convertToAssets`), so the exit fee is borne by the user whose withdrawal triggers a redemption and by nobody else. A withdrawal the vault can serve out of idle triggers none and pays none — that fee stays latent in the position for whoever redeems next. Marking net would instead take the haircut into the share price at investment time, making every holder pre-pay a fee they may never trigger. `ipor-bdusd.js` pins this with a test so a change to the policy fails loudly.

## Tests

35, all green on a fork at block 25933440.

| file | | covers |
|---|---|---|
| `test/erc4626/ipor-bdusd.js` | 7 | direct-depositor parity, exit-fee attribution across idle / redeemed / mixed payouts, high water mark |
| `test/erc4626/ipor-btcdc.js` | 5 | the same, plus the dust-fee drain and fee forwarding |
| `test/erc4626/ipor-hook.js` | 5 | the redemption lock reproduced in-block, and the hook clearing it |
| `test/vault/hook-vault-deposit-cap.js` | 5 | cap behaviour and the ERC-4626 views, on a live vault |
| `test/vault/hook-vault-fallback.js` | 4 | stock-`VaultV2` equivalence with both flags off, on a live vault |
| `test/vault/hook-vault-upstream-drift.js` | 9 | source-level guard that `HookVaultV2._withdraw` has not drifted from `VaultV1._withdraw` |

The drift guard exists because patching the body of `VaultV1._withdraw` recompiles cleanly and leaves `HookVaultV2`'s bytecode byte-identical — the upstream change is silently dropped for any vault on the Hook implementation. It self-tests against five synthetic drifts.

Per repo convention the fork block stays at the committed value; each test file carries its own `Developed and tested at blockNumber` header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)