### PR TITLE
Do not let the yield source's deposit cap stop the keeper

### DIFF
--- a/contracts/strategies/erc4626/GeneralERC4626Strategy.sol
+++ b/contracts/strategies/erc4626/GeneralERC4626Strategy.sol
@@ -20,6 +20,8 @@ contract GeneralERC4626Strategy is BaseUpgradeableStrategy, IHardWorkHooks {
 
   /// @notice Emitted when a fee redemption was refused by the vault and left pending.
   event FeeRedeemDeferred(uint256 amount);
+  /// @notice Emitted when the vault refused a deposit and the underlying was left idle.
+  event SupplyDeferred(uint256 amount);
 
   address public constant harvestMSIG = address(0xF49440C1F012d041802b25A73e5B0B9166a75c02);
 
@@ -243,8 +245,22 @@ contract GeneralERC4626Strategy is BaseUpgradeableStrategy, IHardWorkHooks {
   function _investAllUnderlying() internal onlyNotPausedInvesting {
     address _underlying = underlying();
     uint256 underlyingBalance = IERC20(_underlying).balanceOf(address(this));
-    if (underlyingBalance > 1e3) {
-      _supply(underlyingBalance);
+    // Only offer what the yield source says it will accept. These vaults run a total
+    // deposit cap and `deposit` reverts outright once it is reached, which would take
+    // `doHardWork()` down with it and stop the strategy earning on anything at all.
+    // `maxDeposit` is only a quote - see `_supply` - so this is the cheap first line, not
+    // the guarantee.
+    // The quote is shaved by a tenth of a percent because it is optimistic: these vaults
+    // accrue their management fee on the way in, which lifts total assets and shrinks the
+    // remaining cap inside the very same transaction, so depositing exactly the quoted
+    // headroom is rejected. The margin only ever binds when the strategy is actually up
+    // against the cap - in the normal case the balance is far below it and this is a no-op.
+    // Subtracting a thousandth rather than multiplying by 999: an uncapped vault reports
+    // `type(uint256).max` here, and multiplying that overflows.
+    uint256 headroom = IERC4626(fToken()).maxDeposit(address(this));
+    uint256 toSupply = Math.min(underlyingBalance, headroom.sub(headroom.div(1000)));
+    if (toSupply > 1e3) {
+      _supply(toSupply);
     }
   }
 
@@ -528,7 +544,18 @@ contract GeneralERC4626Strategy is BaseUpgradeableStrategy, IHardWorkHooks {
     address _fToken = fToken();
     IERC20(_underlying).safeApprove(_fToken, 0);
     IERC20(_underlying).safeApprove(_fToken, amount);
-    IERC4626(_fToken).deposit(amount, address(this));
+    // The deposit is allowed to fail. `maxDeposit` is a quote taken before the call, and
+    // these vaults accrue their management fee on the way in - which lifts total assets and
+    // shrinks the remaining cap inside the very same transaction, so a deposit of exactly
+    // the quoted headroom is rejected. A paused or restricted vault refuses in the same
+    // way. None of that should be able to revert `doHardWork()` and every path that calls
+    // it: the underlying simply stays idle, still counted by
+    // `investedUnderlyingBalance()`, and the next hard work tries again.
+    try IERC4626(_fToken).deposit(amount, address(this)) returns (uint256) {
+    } catch {
+      IERC20(_underlying).safeApprove(_fToken, 0);
+      emit SupplyDeferred(amount);
+    }
   }
 
   /**

--- a/test/erc4626/ipor-bdusd.js
+++ b/test/erc4626/ipor-bdusd.js
@@ -250,6 +250,36 @@ describe("Mainnet IPOR Lending bdUSD", function () {
     });
   });
 
+  describe("Yield source deposit cap", function () {
+    it("keeps working when the vault holds more than the PlasmaVault will accept", async function () {
+      // Both IPOR Fusion vaults run a total deposit cap, and `deposit` reverts once it is
+      // reached. Supplying blindly would take doHardWork() down with it and stop the
+      // strategy earning on anything at all.
+      await deploy();
+      const headroom = num(await fToken.maxDeposit(strategy.address));
+      const over = headroom + 500000000000; // headroom + 500,000 USDC
+      await fund(farmer1, String(over));
+      await depositVault(farmer1, underlying, vault, String(over));
+      console.log("  headroom", headroom, "| vault holds", num(await vault.underlyingBalanceInVault()));
+
+      await controller.doHardWork(vault.address, { from: governance });
+
+      const supplied = num(await strategy.currentBalance());
+      const idle = num(await strategy.investedUnderlyingBalance()) - supplied;
+      console.log("  supplied", supplied, "| left idle in the strategy", idle);
+      assert.isTrue(supplied > headroom * 0.99, "it must supply nearly all of what the cap allows");
+      assert.isTrue(supplied <= headroom, "it must not exceed the cap");
+      assert.isTrue(idle > 0, "the remainder must stay idle rather than reverting");
+
+      // Nothing is lost: the vault still accounts for every unit, and holders can exit.
+      const tvl = num(await vault.underlyingBalanceWithInvestment());
+      assert.isTrue(tvl >= over * 0.999, "idle underlying must still count toward TVL");
+      const before = num(await underlying.balanceOf(farmer1));
+      await vault.withdraw((await vault.balanceOf(farmer1)).toString(), { from: farmer1 });
+      assert.isTrue(num(await underlying.balanceOf(farmer1)) - before > 0, "holders must still be able to exit");
+    });
+  });
+
   describe("Exit fee attribution", function () {
     it("charges the PlasmaVault's exit fee to the withdrawing user only", async function () {
       await deploy();


### PR DESCRIPTION
Follow-up to #22, which merged just before this landed.

Both IPOR Fusion vaults run a **total deposit cap** — checked live: bdUSD has ~4.2M USDC of headroom against 809k of assets, BTCdc ~14.5 WBTC against 5.5 — and `deposit` reverts outright once it is reached. `_investAllUnderlying` offered its whole idle balance regardless, so once the Harvest vault held more than the cap allowed, **`doHardWork()` reverted and the strategy stopped earning on everything**, not just the excess.

Reproduced on a fork with 500k USDC over the cap. It is also the failure `test/erc4626/ipor-nvda.js` already shows on the Base repo, where the mirror of this change makes it pass again.

Funds were never at risk — user withdrawals kept working throughout — but the vault would sit dead until governance intervened.

## Why one change wasn't enough

Capping at `maxDeposit` alone still reverted. The quote is **optimistic**: these vaults accrue their management fee on the way in, which lifts total assets and shrinks the remaining cap *inside the same transaction*. Measured, the shortfall was 2,520 units against a 4.04M quote.

So the strategy now offers `maxDeposit` less a thousandth, **and** the deposit itself is allowed to fail. A quote cannot cover a vault that is paused or has become restricted, and the accrual gap scales with time since the last touch rather than with the headroom, so no fixed margin is safe in general. On refusal the approval is cleared, `SupplyDeferred` is emitted, and the underlying stays idle — still counted by `investedUnderlyingBalance()`, supplied by the next hard work.

The margin is `headroom - headroom / 1000`, not `headroom * 999 / 1000`: an **uncapped** vault reports `type(uint256).max` here, and multiplying that overflows. That mistake was caught by the Base NVDA test, which points at an uncapped vault — both vaults in this repo are capped, so nothing here would have found it.

## Result

Nothing is stranded either way: idle underlying is part of the vault's total assets, and holders withdraw normally throughout. With a vault holding 500k USDC more than the cap allows, the strategy supplies 99.9% of the available headroom and leaves the rest idle, where before the hard work reverted.

18 tests green at block 25933440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)